### PR TITLE
Fix reset of Praiding status vars

### DIFF
--- a/modules/other.js
+++ b/modules/other.js
@@ -236,7 +236,7 @@ function Praiding() {
 	debug("Prestige raiding successfull!");
 	debug("Turning AutoMaps back on");
     }
-    if (getPageSetting('Praidingzone').every(isBelowThreshold) && prestraid && !failpraid) {
+    if (getPageSetting('Praidingzone').every(isBelowThreshold)) {
         prestraid = false;
 	failpraid = false
 	prestraidon = false;


### PR DESCRIPTION
    if (getPageSetting('Praidingzone').every(isBelowThreshold) && prestraid && !failpraid) {

changed to 

    if (getPageSetting('Praidingzone').every(isBelowThreshold)) {

If we failed to afford a map, then 
(i) failpraid is true 
(ii) prestraid is false

so the branch resetting failpraid never gets run.  Since getPageSetting('Praidingzone').every(isBelowThreshold) is never true on a Praidingzone, we can safely reset all these variables to false regardless of the state of failpraid or prestraid.