### PR TITLE
Allow scryer overkill outside of ScryUseIn$nature zones

### DIFF
--- a/modules/scryer.js
+++ b/modules/scryer.js
@@ -22,10 +22,6 @@ function useScryerStance() {
     use_auto = use_auto || !game.global.mapsActive && isActiveSpireAT() && getPageSetting('ScryerUseinSpire2') == 0;
     //check Boss NEVERs
     use_auto = use_auto || (getPageSetting('ScryerSkipBoss2') == 1 && game.global.world > getPageSetting('VoidMaps') && game.global.lastClearedCell == 98) || (getPageSetting('ScryerSkipBoss2') == 2 && game.global.lastClearedCell == 98);
-    //Check Nature Min Zone
-    use_auto = use_auto || ((getEmpowerment() == "Poison" && 0 <= getPageSetting('ScryUseinPoison') && (game.global.world < getPageSetting('ScryUseinPoison')))
-      || (getEmpowerment() == "Wind" && 0 <= getPageSetting('ScryUseinWind') && (game.global.world < getPageSetting('ScryUseinWind')))
-      || (getEmpowerment() == "Ice" && 0 <= getPageSetting('ScryUseinIce') && (game.global.world < getPageSetting('ScryUseinIce'))));
     //check Corrupted Never
     var curEnemy = getCurrentEnemy(1);
     var iscorrupt = curEnemy && (curEnemy.mutation == "Corruption" || curEnemy.mutation == "Healthy");
@@ -44,10 +40,6 @@ function useScryerStance() {
     use_scryer = use_scryer || (game.global.mapsActive && getCurrentMapObject().location == "Void" && getPageSetting('ScryerUseinVoidMaps2') == 1);
     //check spire Force
     use_scryer = use_scryer || (!game.global.mapsActive && isActiveSpireAT() && getPageSetting('ScryerUseinSpire2') == 1);
-    //Check Nature Min Zone
-    use_scryer = use_scryer || ((getEmpowerment() == "Poison" && 0 <= getPageSetting('ScryUseinPoison') && (game.global.world >= getPageSetting('ScryUseinPoison')))
-      || (getEmpowerment() == "Wind" && 0 <= getPageSetting('ScryUseinWind') && (game.global.world >= getPageSetting('ScryUseinWind')))
-      || (getEmpowerment() == "Ice" && 0 <= getPageSetting('ScryUseinIce') && (game.global.world >= getPageSetting('ScryUseinIce'))));
     //check Corrupted Force
     if ((iscorrupt && getPageSetting('ScryerSkipCorrupteds2') == 1) || (use_scryer)) {
         setFormation(4);
@@ -85,11 +77,6 @@ function useScryerStance() {
     //If Spire is set to never and is active, don't use overkill setting. //redundant now??
     if (useoverkill && !game.global.mapsActive && isActiveSpireAT() && getPageSetting('ScryerUseinSpire2')==0)
       useoverkill = false;
-    //If lower than nature zone, do not use overkill //redundant now??
-    if (useoverkill && ((getEmpowerment() == "Poison" && (game.global.world <= getPageSetting('ScryUseinPoison')))
-      || (getEmpowerment() == "Wind" && (game.global.world <= getPageSetting('ScryUseinWind')))
-      || (getEmpowerment() == "Ice" &&(game.global.world <= getPageSetting('ScryUseinIce')))))
-      useoverkill = false;
     //Overkill button being on and being able to overkill in S will override any setting other than never spire & nature zone, regardless.
     if (useoverkill && game.portal.Overkill.level > 0) {
         var avgDamage = (baseDamage * (1-getPlayerCritChance()) + (baseDamage * getPlayerCritChance() * getPlayerCritDamageMult()));
@@ -107,9 +94,16 @@ function useScryerStance() {
 //Default. (All Never and Always are accounted for, Overkill has decided whether to run, leaving solely what zones you want to run S in even when you can't overkill)
     var min_zone = getPageSetting('ScryerMinZone');
     var max_zone = getPageSetting('ScryerMaxZone');
+    var valid_nature = ((getEmpowerment() == "Poison" && (game.global.world >= getPageSetting('ScryUseinPoison')) && 0 <= getPageSetting('ScryUseinPoison'))
+      || (getEmpowerment() == "Wind" && (game.global.world >= getPageSetting('ScryUseinWind')) && 0 <= getPageSetting('ScryUseinWind'))
+      || (getEmpowerment() == "Ice" &&(game.global.world >= getPageSetting('ScryUseinIce')) && 0 <= getPageSetting('ScryUseinIce')));
     var valid_min = game.global.world >= min_zone;
     var valid_max = max_zone <= 0 || game.global.world < max_zone;
-    if (valid_min && valid_max) {
+
+    // This allows ScryInX nature settings to override min scrying zone but not max scrying zone settings
+    // if ((valid_min || valid_nature) && valid_max) {
+    // This allows ScryInX nature settings to override both min and max scrying zone settings
+    if ((valid_min && valid_max) || valid_nature) {
         if (oktoswitch)
             setFormation(4);
         wantToScry = true;


### PR DESCRIPTION
Moves a bunch of nature tests down to the end past overkill decisions; may solve some undesired scryer stance use in edge cases arising from a test which didn't account for ScryUseInX = -1.