### PR TITLE
Fix various maps issues

### DIFF
--- a/modules/maps.js
+++ b/modules/maps.js
@@ -410,9 +410,11 @@ function autoMap() {
     });
     //if there are no non-unique maps, there will be nothing in keysSorted, so set to create a map
     var highestMap;
-    if (keysSorted[0])
+    var lowestMap;
+    if (keysSorted[0]) {
         highestMap = keysSorted[0];
-    else
+        lowestMap = keysSorted[keysSorted.length - 1];
+    } else
         selectedMap = "create";
 
     //Look through all the maps we have and figure out, find and Run Uniques if we need to
@@ -577,10 +579,14 @@ function autoMap() {
             //if preSpireFarming x minutes is true, switch over from wood maps to metal maps.
             if (preSpireFarming) {
                 var spiremaplvl = (game.talents.mapLoot.purchased && MODULES["maps"].SpireFarm199Maps) ? game.global.world - 1 : game.global.world;
-                if (game.global.mapsOwnedArray[highestMap].level >= spiremaplvl && game.global.mapsOwnedArray[highestMap].location == ((customVars.preferGardens && game.global.decayDone) ? 'Plentiful' : 'Mountain'))
-                    selectedMap = game.global.mapsOwnedArray[highestMap].id;
-                else
-                    selectedMap = "create";
+                selectedMap = "create";
+                for (var i = 0; i < keysSorted.length; i++) {
+                    if (game.global.mapsOwnedArray[keysSorted[i]].level >= spiremaplvl &&
+                            game.global.mapsOwnedArray[keysSorted[i]].location == ((customVars.preferGardens && game.global.decayDone) ? 'Plentiful' : 'Mountain')) {
+                        selectedMap = game.global.mapsOwnedArray[i].id;
+                    break;
+                    }
+                }
                 //if needPrestige, TRY to find current level map as the highest level map we own.
             } else if (needPrestige || (extraMapLevels > 0)) {
                 if ((game.global.world + extraMapLevels) == game.global.mapsOwnedArray[highestMap].level)
@@ -783,7 +789,14 @@ function autoMap() {
                     debug("Too many maps, recycling now: ", "maps", 'th-large');
                     recycleBelow(true);
                     debug("Retrying, Buying a Map, level: #" + maplvlpicked, "maps", 'th-large');
-                    buyMap();
+                    result = buyMap();
+                    if (result == -2) {
+                        recycleMap(lowestMap);
+                        result = buyMap();
+                        if (result == -2) debug("AutoMaps unable to recycle to buy map!")
+                        else
+                          debug("Retrying map buy after recycling lowest level map");
+                    }
                 }
             }
             //if we already have a map picked, run it

--- a/modules/maps.js
+++ b/modules/maps.js
@@ -583,7 +583,7 @@ function autoMap() {
                 for (var i = 0; i < keysSorted.length; i++) {
                     if (game.global.mapsOwnedArray[keysSorted[i]].level >= spiremaplvl &&
                             game.global.mapsOwnedArray[keysSorted[i]].location == ((customVars.preferGardens && game.global.decayDone) ? 'Plentiful' : 'Mountain')) {
-                        selectedMap = game.global.mapsOwnedArray[i].id;
+                        selectedMap = game.global.mapsOwnedArray[keysSorted[i]].id;
                     break;
                     }
                 }

--- a/modules/other.js
+++ b/modules/other.js
@@ -195,6 +195,7 @@ function findLastBionic() {
 //Praiding
 
 function Praiding() {
+    var pMap;
     if (getPageSetting('Praidingzone').length) {
    	if (getPageSetting('Praidingzone').includes(game.global.world) && !prestraid && !failpraid) {
             debug('World Zone matches a Praiding Zone!');
@@ -233,7 +234,8 @@ function Praiding() {
                 }
 	    }
 	    if (mapbought == true) {
-                selectMap(game.global.mapsOwnedArray[game.global.mapsOwnedArray.length-1].id);
+		pMap = game.global.mapsOwnedArray[game.global.mapsOwnedArray.length-1].id;
+                selectMap(pMap);
 		runMap();
             }
             if (!prestraid && !failpraid && !game.global.repeatMap) {
@@ -249,7 +251,8 @@ function Praiding() {
 	
     if (getPageSetting('AutoMaps') == 0 && game.global.preMapsActive && prestraid && !failpraid) {
         autoTrimpSettings["AutoMaps"].value = 1;
-	debug("Prestige raiding successfull!");
+	debug("Prestige raiding successfull! - recycling Praid map");
+	recycleMap(pMap);
 	debug("Turning AutoMaps back on");
     }
     if (getPageSetting('Praidingzone').every(isBelowThreshold)) {
@@ -507,6 +510,7 @@ function helptrimpsnotdie () {
 //Daily stuff couldnt be bothered to add it to original
 
 function dailyPraiding() {
+    var dpMap;
     if (getPageSetting('dPraidingzone').length) {
    	if (getPageSetting('dPraidingzone').includes(game.global.world) && !dprestraid && !dfailpraid) {
             debug('World Zone matches a Daily Praiding Zone!');
@@ -545,7 +549,8 @@ function dailyPraiding() {
                 }
 	    }
 	    if (dmapbought == true) {
-                selectMap(game.global.mapsOwnedArray[game.global.mapsOwnedArray.length-1].id);
+		dpMap = game.global.mapsOwnedArray[game.global.mapsOwnedArray.length-1].id;
+                selectMap(dpMap);
 		runMap();
             }
             if (!dprestraid && !dfailpraid && !game.global.repeatMap) {
@@ -561,7 +566,8 @@ function dailyPraiding() {
 	
     if (getPageSetting('AutoMaps') == 0 && game.global.preMapsActive && dprestraid && !dfailpraid) {
         autoTrimpSettings["AutoMaps"].value = 1;
-	debug("Daily Prestige Raiding successfull!");
+	debug("Daily Prestige Raiding successfull! - recycling Praid map");
+	recycleMap(dpMap);
 	debug("Turning AutoMaps back on");
     }
     if (getPageSetting('dPraidingzone').every(isBelowThreshold)) {


### PR DESCRIPTION
Let's see if I can manage to submit this this time without screwing it up again...

Fixes a couple of maps issues:

* Stops AT getting caught in a loop sometimes when spire farming if plus maps beyond the spire level have been created

* Handles a case where AT can try and fail to recycle maps and get stuck in a loop (should be rare, but can be brought about if automaps gets confused or bugged)

* Deletes Praiding maps after we're done with them to stop AT using them for farming/mapbonus rather than buying a more suitable map