### PR TITLE
Fix infinite loop in autoheirloom3

### DIFF
--- a/modules/heirlooms.js
+++ b/modules/heirlooms.js
@@ -150,6 +150,7 @@ function autoheirlooms3() {
                             selectHeirloom(carryshield.index, 'heirloomsExtra');
                             carryHeirloom();
                         }
+			else break;
                 }
 	}
 
@@ -162,6 +163,7 @@ function autoheirlooms3() {
                             selectHeirloom(carrystaff.index, 'heirloomsExtra');
                             carryHeirloom();
                         }
+			else break;
                 }
 	}
 
@@ -174,6 +176,7 @@ function autoheirlooms3() {
                             selectHeirloom(carrycore.index, 'heirloomsExtra');
                             carryHeirloom();
                         }
+			else break;
                 }
 	}
 


### PR DESCRIPTION
If e.g. keep only core, but there is a non-core, and carry isn't full, it loops forever since there's always an extra (non-core) heirloom.
Now break if no more e.g. cores to consider