### PR TITLE
Update calcBadGuyDmg to not double count given enemy

### DIFF
--- a/modules/calc.js
+++ b/modules/calc.js
@@ -363,7 +363,7 @@ function calcBadGuyDmg(enemy,attack,daily,maxormin,disableFlucts) {
     var maxFluct = -1;
     var minFluct = -1;
 
-    if (game.global.challengeActive){
+    if (!enemy && game.global.challengeActive){
         if (game.global.challengeActive == "Coordinate"){
             number *= getBadCoordLevel();
         }
@@ -400,7 +400,7 @@ function calcBadGuyDmg(enemy,attack,daily,maxormin,disableFlucts) {
         if (daily)
             number = calcDailyAttackMod(number);
     }
-    if (game.global.usingShriek) {
+    if (!enemy && game.global.usingShriek) {
         number *= game.mapUnlocks.roboTrimp.getShriekValue();
     }
 


### PR DESCRIPTION
It appears as though enemy.attack already includes challenge modifiers (and possibly shriek?), so they don't need to be applied again. 
Noticed/tested on oblit when looking into stance always being H, where this returned e32 higher than the displayed attack, but the base enemy.attack looked correct minus flux calc.
Might need to check shriek and other challenges, didn't test that.