### PR TITLE
Add some troubleshooting to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ Yellow - Upgrade is not affordable
 Orange - Upgrade is affordable, but will lower stats
 
 Red - Will buy next
+
+## Troubleshooting
+
+**Combat won't start** - Make sure you have enabled the Better Auto Fight/Vanilla setting in Combat & Stance Settings. If you're not on dark theme, you may see a tiny thin black bar in combat, click it to show this setting.


### PR DESCRIPTION
I ran into the issue of not being able to start combat automatically. I ended up getting help in the discord but since this is something people may encounter very early I think it should be in the readme.

Here are a few issues people opened that may have been solved by having this info in a prominent place: #118 #86 #72 

This can also be expanded for other repeated questions or useful information. In general it is pretty hard to find info on how AT functions. Discord is not a good place to have information presented in an organized manner because chat goes on and info is lost to history. Reddit can be an option but that too can get out of date and sometimes hard to find. The readme is a good option, wiki would be even better but harder to maintain.