### PR TITLE
[Fix] No longer double count helium spent for fixed perk allocation during respec

### DIFF
--- a/modules/perks.js
+++ b/modules/perks.js
@@ -500,7 +500,7 @@ AutoPerks.applyCalculationsRespec = function(perks,remainingHelium){
         for(var i in perks) {
             var capitalized = AutoPerks.capitaliseFirstLetter(perks[i].name);
             game.global.buyAmt = perks[i].level;
-            if (getPortalUpgradePrice(capitalized) <= remainingHelium) {
+            if (getPortalUpgradePrice(capitalized) <= remainingHelium || perks[i].fixed) {
                 if (MODULES["perks"].showDetails)
                     debug("AutoPerks-Respec Buying: " + capitalized + " " + perks[i].level, "perks");
                 buyPortalUpgrade(capitalized);


### PR DESCRIPTION
During respec, pre-allocated fixed perk costs are removed from available helium. These same fixed perks are then compared against that remaining helium to determine if it can be purchased - even though this cost has already been considered. Concretely as an example, buying Capable (5) with under 2e12 He causes AT to remove all Capable upgrades as it appears to be unaffordable.