### PR TITLE
Fixing variable name issue

### DIFF
--- a/SettingsGUI.js
+++ b/SettingsGUI.js
@@ -1944,9 +1944,9 @@ function updateCustomButtons() {
 	//Shields
 	radonon && hson ? turnOn('Rhsshield') : turnOff('Rhsshield');
 	var hsshieldon = (getPageSetting('Rhsshield') == true);
-	radonon && hson ? turnOn('Rhsz') : turnOff('Rhsz');
-	radonon && hson ? turnOn('Rhs1') : turnOff('Rhs1');
-	radonon && hson ? turnOn('Rhs2') : turnOff('Rhs2');
+	radonon && hson && hsshieldon ? turnOn('Rhsz') : turnOff('Rhsz');
+	radonon && hson && hsshieldon ? turnOn('Rhs1') : turnOff('Rhs1');
+	radonon && hson && hsshieldon ? turnOn('Rhs2') : turnOff('Rhs2');
 	
 	//Staffs
 	radonon && hson ? turnOn('Rhsstaff') : turnOff('Rhsstaff');

--- a/modules/heirlooms.js
+++ b/modules/heirlooms.js
@@ -489,10 +489,10 @@ function Rheirloomswap() {
 		if (getPageSetting('Rhsworldstaff') != "undefined" && game.global.mapsActive == false) {
 			Rhsworldstaffequip();
 		}
-		if (getPageSetting('Rhsmapstaff') != "undefined" && (Rshouldtributefarm == false || getPageSetting('Rhstributestaff') == "undefined") && game.global.mapsActive == true) {
+		if (getPageSetting('Rhsmapstaff') != "undefined" && (Rshouldtimefarm == false || getPageSetting('Rhstributestaff') == "undefined") && game.global.mapsActive == true) {
 			Rhsmapstaffequip();
 		}
-		if (getPageSetting('Rhstributestaff') != "undefined" && getPageSetting('Rhsstaff') && Rshouldtributefarm == true && game.global.mapsActive == true) {
+		if (getPageSetting('Rhstributestaff') != "undefined" && getPageSetting('Rhsstaff') && Rshouldtimefarm == true && game.global.mapsActive == true) {
 			Rhstributestaffequip();
 		}
 	}


### PR DESCRIPTION
Due to having split up Time Farm and Tribute Farm when copy pasting code I forgot to adjust the Rshouldtributefarm variable to Rshouldtimefarm and only noticed it when I went to double check something and there were errors relating to the heirloom code. 