### PR TITLE
Fixing equip costs when autoBattle upg isn't unlocked

### DIFF
--- a/modules/equipment.js
+++ b/modules/equipment.js
@@ -500,8 +500,8 @@ function RequipCost(gameResource, equip) {
     var price = parseFloat(getBuildingItemPrice(gameResource, equip.Resource, equip.Equip, 1));
     if (equip.Equip)
         price = Math.ceil(price * (Math.pow(1 - game.portal.Artisanistry.modifier, game.portal.Artisanistry.radLevel)));
-        price *= autoBattle.oneTimers.Artisan.getMult();
-        if (game.global.challenges == "Pandemonium") { price *= game.challenges.Pandemonium.getEnemyMult();}
+        price *= autoBattle.oneTimers.Artisan.owned ? autoBattle.oneTimers.Artisan.getMult() : 1;
+        if (game.global.challenges == "Pandemonium") price *= game.challenges.Pandemonium.getEnemyMult();
     /*else
         price = Math.ceil(price * (Math.pow(1 - game.portal.Resourceful.modifier, game.portal.Resourceful.radLevel)));*/
     return price;
@@ -851,8 +851,8 @@ function mostEfficientEquipment(fakeLevels = {}) {
     ];
 
     var artBoost = Math.pow(1 - game.portal.Artisanistry.modifier, game.portal.Artisanistry.radLevel);
-    artBoost *= autoBattle.oneTimers.Artisan.getMult();
-    if (game.global.challenges == "Pandemonium") { artBoost *= game.challenges.Pandemonium.getEnemyMult();}
+    artBoost *= autoBattle.oneTimers.Artisan.owned ? autoBattle.oneTimers.Artisan.getMult() : 1;
+    if (game.global.challenges == "Pandemonium") artBoost *= game.challenges.Pandemonium.getEnemyMult();
 
     for (var i in RequipmentList) {
         var nextLevelCost = game.equipment[i].cost[RequipmentList[i].Resource][0] * Math.pow(game.equipment[i].cost[RequipmentList[i].Resource][1], game.equipment[i].level + fakeLevels[i]) * artBoost;
@@ -929,8 +929,8 @@ function buyPrestigeMaybe(equipName) {
     var equipStat = (typeof equipment.attack !== 'undefined') ? 'attack' : 'health';
 
     var artBoost = Math.pow(1 - game.portal.Artisanistry.modifier, game.portal.Artisanistry.radLevel);
-    artBoost *= autoBattle.oneTimers.Artisan.getMult();
-    if (game.global.challenges == "Pandemonium") { artBoost *= game.challenges.Pandemonium.getEnemyMult();}
+    artBoost *= autoBattle.oneTimers.Artisan.owned ? autoBattle.oneTimers.Artisan.getMult() : 1;
+    if (game.global.challenges == "Pandemonium") artBoost *= game.challenges.Pandemonium.getEnemyMult();
 
     var prestigeUpgradeName = "";
     var allUpgradeNames = Object.getOwnPropertyNames(game.upgrades);
@@ -1072,6 +1072,8 @@ function equipfarmdynamicHD() {
 	
 function estimateEquipsForZone() {
     var artBoost = Math.pow(1 - game.portal.Artisanistry.modifier, game.portal.Artisanistry.radLevel);
+	artBoost *= autoBattle.oneTimers.Artisan.owned ? autoBattle.oneTimers.Artisan.getMult() : 1;
+	if (game.global.challengeActive == "Pandemonium") artBoost *= game.challenges.Pandemonium.getEnemyMult();
     var MAX_EQUIP_DELTA = 700;
 
     // calculate stats needed pass zone


### PR DESCRIPTION
The Artisan upgrade from autoBattle returns the actual value and not 1 if it's locked, will mess up the calcs for anybody that has AB unlocked but hasn't purchase the one time upgrade.

Unsure if that last line in estimateEquipsForZone() is necessary but no real harm in implementing it.