### PR TITLE
Updating alch farm to use appropriate biome

### DIFF
--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -1,4 +1,4 @@
-var ATversion='Zek v4.5.0',atscript=document.getElementById('AutoTrimps-script'),basepath='https://Zorn192.github.io/AutoTrimps/',modulepath='modules/';null!==atscript&&(basepath=atscript.src.replace(/AutoTrimps2\.js$/,''));
+var ATversion='Zek v4.5.0',atscript=document.getElementById('AutoTrimps-script'),basepath='https://SadAugust.github.io/AutoTrimps_Testing/',modulepath='modules/';null!==atscript&&(basepath=atscript.src.replace(/AutoTrimps2\.js$/,''));
 function ATscriptLoad(a,b){null==b&&debug('Wrong Syntax. Script could not be loaded. Try ATscriptLoad(modulepath, \'example.js\'); ');var c=document.createElement('script');null==a&&(a=''),c.src=basepath+a+b+'.js',c.id=b+'_MODULE',document.head.appendChild(c)}
 function ATscriptUnload(a){var b=document.getElementById(a+"_MODULE");b&&(document.head.removeChild(b),debug("Removing "+a+"_MODULE","other"))}
 ATscriptLoad(modulepath, 'utils');

--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -1,4 +1,4 @@
-var ATversion='Zek v4.5.0',atscript=document.getElementById('AutoTrimps-script'),basepath='https://SadAugust.github.io/AutoTrimps_Testing/',modulepath='modules/';null!==atscript&&(basepath=atscript.src.replace(/AutoTrimps2\.js$/,''));
+var ATversion='Zek v4.5.0',atscript=document.getElementById('AutoTrimps-script'),basepath='https://Zorn192.github.io/AutoTrimps/',modulepath='modules/';null!==atscript&&(basepath=atscript.src.replace(/AutoTrimps2\.js$/,''));
 function ATscriptLoad(a,b){null==b&&debug('Wrong Syntax. Script could not be loaded. Try ATscriptLoad(modulepath, \'example.js\'); ');var c=document.createElement('script');null==a&&(a=''),c.src=basepath+a+b+'.js',c.id=b+'_MODULE',document.head.appendChild(c)}
 function ATscriptUnload(a){var b=document.getElementById(a+"_MODULE");b&&(document.head.removeChild(b),debug("Removing "+a+"_MODULE","other"))}
 ATscriptLoad(modulepath, 'utils');

--- a/modules/maps.js
+++ b/modules/maps.js
@@ -1388,35 +1388,31 @@ function RautoMap() {
 			
 			var alchstacksfarmindex = alchfarmzone.indexOf(game.global.world);
 			var alchstackszones = alchfarmstacks[alchstacksfarmindex];
+			
 			if (alchstackszones != undefined) {
-			    var potion;
-			    var potionletter = alchstackszones[0];
-			    if (potionletter == 'h') { 
-				potion = alchObj.getPotionCount('Herby Brew');  
-				potionletter = "Herby Brew";
-			    }
-			    else if (potionletter == 'f') { 
-				potion = alchObj.getPotionCount('Potion of Finding'); 
-				potionletter = "Potion of Finding"; 
-			    }
-			    else if (potionletter == 'g') { 
-				potion = alchObj.getPotionCount('Gaseous Brew');  
-				potionletter = "Gaseous Brew";
-			    }
-			    else if (potionletter == 'v') { 
-				potion = alchObj.getPotionCount('Potion of the Void');  
-				potionletter = "Potion of the Void";
-			    }
-			    else if (potionletter == 's') { 
-				potion = alchObj.getPotionCount('Potion of Strength');  
-				potionletter = "Potion of Strength";
-			    }
+				//Working out which potion the input corresponds to.
+				potion = 	alchstackszones[0] == 'h' ? 0 : 
+							alchstackszones[0] == 'g' ? 1 : 
+							alchstackszones[0] == 'f' ? 2 : 
+							alchstackszones[0] == 'v' ? 3 : 
+							alchstackszones[0] == 's' ? 4 : 
+							undefined;
+				//Alchemy biome selection, will select Farmlands if it's unlocked and appropriate otherwise it'll use the default map type for that herb.
+				alchbiome = alchObj.potionNames[potion] == alchObj.potionNames[0] ? game.global.farmlandsUnlocked && getFarmlandsResType() == "Metal" ? "Farmlands" : "Mountain" : 
+								alchObj.potionNames[potion] == alchObj.potionNames[1] ? game.global.farmlandsUnlocked && getFarmlandsResType() == "Wood" ? "Farmlands" : "Forest" : 
+								alchObj.potionNames[potion] == alchObj.potionNames[2] ? game.global.farmlandsUnlocked && getFarmlandsResType() == "Food" ? "Farmlands" : "Sea" : 
+								alchObj.potionNames[potion] == alchObj.potionNames[3] ? game.global.farmlandsUnlocked && getFarmlandsResType() == "Gems" ? "Farmlands" : "Depths" : 
+								alchObj.potionNames[potion] == alchObj.potionNames[4] ? game.global.farmlandsUnlocked && getFarmlandsResType() == "Any" ? "Farmlands" : game.global.decayDone ? "Plentiful" : "Random" : 
+								game.global.farmlandsUnlocked && getFarmlandsResType() == "Any" ? "Farmlands" : game.global.decayDone ? "Plentiful" : "Random";
 
-			    if (alchstackszones.substring(1) > potion) { alchObj.craftPotion(potionletter); }
-
-			    if (alchfarmzone.includes(game.global.world) && alchstackszones.substring(1) > potion) {
-			        Rshouldalchfarm = true;
-			    }
+				if (potion == undefined) debug('You have an incorrect value in AF: Potions, each input needs to start with h, g, f, v, or s.');
+				else {
+					if (alchstackszones.toString().replace(/[^\d:-]/g, '') > alchObj.potionsOwned[potion]) alchObj.craftPotion(alchObj.potionNames[potion]);
+					if (alchfarmzone.includes(game.global.world) && alchstackszones.toString().replace(/[^\d,:-]/g, '') > alchObj.potionsOwned[potion]) {
+						Rshouldalchfarm = true;
+					}
+				}
+			}
 			}
 		}
 
@@ -1709,7 +1705,7 @@ function RautoMap() {
 	    } else if (Rshouldalchfarm && !Rshouldtimefarm && !Rshouldtributefarm && !Rshouldequipfarm && !Rshouldshipfarm) {
                 if (getPageSetting('Ralchfarmlevel') == 0) {
                     for (var map in game.global.mapsOwnedArray) {
-                        if (!game.global.mapsOwnedArray[map].noRecycle && game.global.world == game.global.mapsOwnedArray[map].level) {
+                        if (!game.global.mapsOwnedArray[map].noRecycle && game.global.world == game.global.mapsOwnedArray[map].level && game.global.mapsOwnedArray[map].location == alchbiome) {
                             selectedMap = game.global.mapsOwnedArray[map].id;
 			    break;
                         } else {
@@ -1722,7 +1718,7 @@ function RautoMap() {
                     var alchlevelzones = alchfarmlevel[alchfarmlevelindex];
                     if (alchlevelzones > 0) {
                         for (var map in game.global.mapsOwnedArray) {
-                            if (!game.global.mapsOwnedArray[map].noRecycle && ((game.global.world + alchlevelzones) == game.global.mapsOwnedArray[map].level)) {
+                            if (!game.global.mapsOwnedArray[map].noRecycle && ((game.global.world + alchlevelzones) == game.global.mapsOwnedArray[map].level && game.global.mapsOwnedArray[map].location == alchbiome)) {
                                 selectedMap = game.global.mapsOwnedArray[map].id;
 				break;
                             } else {
@@ -1731,7 +1727,7 @@ function RautoMap() {
                         }
                     } else if (alchlevelzones == 0) {
                         for (var map in game.global.mapsOwnedArray) {
-                            if (!game.global.mapsOwnedArray[map].noRecycle && game.global.world == game.global.mapsOwnedArray[map].level) {
+                            if (!game.global.mapsOwnedArray[map].noRecycle && game.global.world == game.global.mapsOwnedArray[map].level && game.global.mapsOwnedArray[map].location == alchbiome) {
                                 selectedMap = game.global.mapsOwnedArray[map].id;
 				break;
                             } else {
@@ -1740,7 +1736,7 @@ function RautoMap() {
                         }
                     } else if (alchlevelzones < 0) {
                         for (var map in game.global.mapsOwnedArray) {
-                            if (!game.global.mapsOwnedArray[map].noRecycle && ((game.global.world + alchlevelzones) == game.global.mapsOwnedArray[map].level)) {
+                            if (!game.global.mapsOwnedArray[map].noRecycle && ((game.global.world + alchlevelzones) == game.global.mapsOwnedArray[map].level && game.global.mapsOwnedArray[map].location == alchbiome)) {
                                 selectedMap = game.global.mapsOwnedArray[map].id;
 				break;
                             } else {
@@ -2315,20 +2311,12 @@ function RautoMap() {
 		
 	                var alchfarmzone = getPageSetting('Ralchfarmzone');
                         var alchfarmlevel = getPageSetting('Ralchfarmlevel');
-	                var alchfarmselection = getPageSetting('Ralchfarmselection').split(',');
 
                         var alchfarmlevelindex = alchfarmzone.indexOf(game.global.world);
                         var alchlevelzones = alchfarmlevel[alchfarmlevelindex];
                         var alchfarmselectionindex = alchfarmzone.indexOf(game.global.world);
-                        var selection = alchfarmselection[alchfarmselectionindex];
-	                if (selection == 'm') selection = "Mountain";
-                        else if (selection == 'f') selection = "Forest";
-                        else if (selection == 's') selection = "Sea";
-                        else if (selection == 'd') selection = "Depths";
-                        else if (selection == 'g') selection = "Plentiful";
-                        else if (selection == 'l') selection = "Farmlands";
 
-	                alchfragmin(alchlevelzones, selection);
+	                alchfragmin(alchlevelzones, alchbiome);
 		        }
                     }
                 }

--- a/modules/maps.js
+++ b/modules/maps.js
@@ -854,8 +854,6 @@ function RupdateAutoMapsStatus(get) {
     }
 }
 
-
-
 function RautoMap() {
 
     //Quest

--- a/modules/maps.js
+++ b/modules/maps.js
@@ -1388,8 +1388,7 @@ function RautoMap() {
 			
 			var alchstacksfarmindex = alchfarmzone.indexOf(game.global.world);
 			var alchstackszones = alchfarmstacks[alchstacksfarmindex];
-			
-			if (alchstackszones != undefined) {
+            if (alchstackszones != undefined) {
 				//Working out which potion the input corresponds to.
 				potion = 	alchstackszones[0] == 'h' ? 0 : 
 							alchstackszones[0] == 'g' ? 1 : 
@@ -1412,7 +1411,6 @@ function RautoMap() {
 						Rshouldalchfarm = true;
 					}
 				}
-			}
 			}
 		}
 
@@ -1705,7 +1703,7 @@ function RautoMap() {
 	    } else if (Rshouldalchfarm && !Rshouldtimefarm && !Rshouldtributefarm && !Rshouldequipfarm && !Rshouldshipfarm) {
                 if (getPageSetting('Ralchfarmlevel') == 0) {
                     for (var map in game.global.mapsOwnedArray) {
-                        if (!game.global.mapsOwnedArray[map].noRecycle && game.global.world == game.global.mapsOwnedArray[map].level && game.global.mapsOwnedArray[map].location == alchbiome) {
+                        if (!game.global.mapsOwnedArray[map].noRecycle && game.global.world == game.global.mapsOwnedArray[map].level) {
                             selectedMap = game.global.mapsOwnedArray[map].id;
 			    break;
                         } else {
@@ -1718,7 +1716,7 @@ function RautoMap() {
                     var alchlevelzones = alchfarmlevel[alchfarmlevelindex];
                     if (alchlevelzones > 0) {
                         for (var map in game.global.mapsOwnedArray) {
-                            if (!game.global.mapsOwnedArray[map].noRecycle && ((game.global.world + alchlevelzones) == game.global.mapsOwnedArray[map].level && game.global.mapsOwnedArray[map].location == alchbiome)) {
+                            if (!game.global.mapsOwnedArray[map].noRecycle && ((game.global.world + alchlevelzones) == game.global.mapsOwnedArray[map].level)) {
                                 selectedMap = game.global.mapsOwnedArray[map].id;
 				break;
                             } else {
@@ -1727,7 +1725,7 @@ function RautoMap() {
                         }
                     } else if (alchlevelzones == 0) {
                         for (var map in game.global.mapsOwnedArray) {
-                            if (!game.global.mapsOwnedArray[map].noRecycle && game.global.world == game.global.mapsOwnedArray[map].level && game.global.mapsOwnedArray[map].location == alchbiome) {
+                            if (!game.global.mapsOwnedArray[map].noRecycle && game.global.world == game.global.mapsOwnedArray[map].level) {
                                 selectedMap = game.global.mapsOwnedArray[map].id;
 				break;
                             } else {
@@ -1736,7 +1734,7 @@ function RautoMap() {
                         }
                     } else if (alchlevelzones < 0) {
                         for (var map in game.global.mapsOwnedArray) {
-                            if (!game.global.mapsOwnedArray[map].noRecycle && ((game.global.world + alchlevelzones) == game.global.mapsOwnedArray[map].level && game.global.mapsOwnedArray[map].location == alchbiome)) {
+                            if (!game.global.mapsOwnedArray[map].noRecycle && ((game.global.world + alchlevelzones) == game.global.mapsOwnedArray[map].level)) {
                                 selectedMap = game.global.mapsOwnedArray[map].id;
 				break;
                             } else {
@@ -2250,78 +2248,76 @@ function RautoMap() {
                 updateMapCost();
             }
         if (Rshouldalchfarm && !Rshouldtimefarm && !Rshouldtributefarm && !Rshoulddoquest && !Rshouldequipfarm && !Rshouldshipfarm) {
-		var alchfragcheck = true;
-		if (getPageSetting('Ralchfarmfrag') == true) {
-                    if (alchfrag() == true) {
-                        alchfragcheck = true;
-                        Ralchfragfarming = false;
-                    } else if (alchfrag() == false && Rshouldalchfarm) {
-                        Ralchfragfarming = true;
-                        alchfragcheck = false;
-                        if (!alchfragcheck && alchfragmappy == undefined && !alchfragmappybought && game.global.preMapsActive && Rshouldalchfarm) {
-                            debug("Check complete for alch frag map");
-                            alchfragmap();
-                            if ((updateMapCost(true) <= game.resources.fragments.owned)) {
-                                buyMap();
-                                alchfragmappybought = true;
-                                if (alchfragmappybought) {
-                                    alchfragmappy = game.global.mapsOwnedArray[game.global.mapsOwnedArray.length - 1].id;
-                                    debug("alch frag map bought");
-                                }
+            var alchfragcheck = true;
+            if (getPageSetting('Ralchfarmfrag') == true) {
+                if (alchfrag() == true) {
+                    alchfragcheck = true;
+                    Ralchfragfarming = false;
+                } else if (alchfrag() == false && Rshouldalchfarm) {
+                    Ralchfragfarming = true;
+                    alchfragcheck = false;
+                    if (!alchfragcheck && alchfragmappy == undefined && !alchfragmappybought && game.global.preMapsActive && Rshouldalchfarm) {
+                        debug("Check complete for alch frag map");
+                        alchfragmap();
+                        if ((updateMapCost(true) <= game.resources.fragments.owned)) {
+                            buyMap();
+                            alchfragmappybought = true;
+                            if (alchfragmappybought) {
+                                alchfragmappy = game.global.mapsOwnedArray[game.global.mapsOwnedArray.length - 1].id;
+                                debug("alch frag map bought");
                             }
                         }
-                        if (!alchfragcheck && game.global.preMapsActive && !game.global.mapsActive && alchfragmappybought && alchfragmappy != undefined && Rshouldalchfarm) {
-                            debug("running alch frag map");
-                            selectedMap = alchfragmappy;
-                            selectMap(alchfragmappy);
-                            runMap();
-                            RlastMapWeWereIn = getCurrentMapObject();
-                            alchprefragmappy = alchfragmappy;
-                            alchfragmappy = undefined;
-                        }
-                        if (!alchfragcheck && game.global.mapsActive && alchfragmappybought && alchprefragmappy != undefined && Rshouldalchfarm) {
-                            if (alchfrag() == false) {
-                                if (!game.global.repeatMap) {
-                                    repeatClicked();
-                                }
-                            } else if (alchfrag() == true) {
-                                if (game.global.repeatMap) {
-                                    repeatClicked();
-                                    mapsClicked();
-                                }
-                                if (game.global.preMapsActive && alchfragmappybought && alchprefragmappy != undefined && Rshouldalchfarm) {
-                                    alchfragmappybought = false;
-                                }
-                                if (alchprefragmappy != undefined) {
-                                    recycleMap(getMapIndex(alchprefragmappy));
-                                    alchprefragmappy = undefined;
-                                }
-                                alchfragcheck = true;
-                                Ralchfragfarming = false;
-                            }
-                        }
-                    } else {
-                        alchfragcheck = true;
-                        Ralchfragfarming = false;
                     }
+                    if (!alchfragcheck && game.global.preMapsActive && !game.global.mapsActive && alchfragmappybought && alchfragmappy != undefined && Rshouldalchfarm) {
+                        debug("running alch frag map");
+                        selectedMap = alchfragmappy;
+                        selectMap(alchfragmappy);
+                        runMap();
+                        RlastMapWeWereIn = getCurrentMapObject();
+                        alchprefragmappy = alchfragmappy;
+                        alchfragmappy = undefined;
+                    }
+                    if (!alchfragcheck && game.global.mapsActive && alchfragmappybought && alchprefragmappy != undefined && Rshouldalchfarm) {
+                        if (alchfrag() == false) {
+                            if (!game.global.repeatMap) {
+                                repeatClicked();
+                            }
+                        } else if (alchfrag() == true) {
+                            if (game.global.repeatMap) {
+                                repeatClicked();
+                                mapsClicked();
+                            }
+                            if (game.global.preMapsActive && alchfragmappybought && alchprefragmappy != undefined && Rshouldalchfarm) {
+                                alchfragmappybought = false;
+                            }
+                            if (alchprefragmappy != undefined) {
+                                recycleMap(getMapIndex(alchprefragmappy));
+                                alchprefragmappy = undefined;
+                            }
+                            alchfragcheck = true;
+                            Ralchfragfarming = false;
+                        }
+                    }
+                } else {
+                    alchfragcheck = true;
+                    Ralchfragfarming = false;
                 }
-                if (alchfragcheck && getPageSetting('Ralchfarmlevel') != 0) {
-                    if (alchfarmzone.includes(game.global.world)) {
-			if (Rshouldalchfarm) {
-		
-	                var alchfarmzone = getPageSetting('Ralchfarmzone');
+            }
+            if (alchfragcheck && getPageSetting('Ralchfarmlevel') != 0) {
+                if (alchfarmzone.includes(game.global.world)) {
+                    if (Rshouldalchfarm) {
+                
+                        var alchfarmzone = getPageSetting('Ralchfarmzone');
                         var alchfarmlevel = getPageSetting('Ralchfarmlevel');
-
                         var alchfarmlevelindex = alchfarmzone.indexOf(game.global.world);
                         var alchlevelzones = alchfarmlevel[alchfarmlevelindex];
-                        var alchfarmselectionindex = alchfarmzone.indexOf(game.global.world);
 
-	                alchfragmin(alchlevelzones, alchbiome);
-		        }
+                        alchfragmin(alchlevelzones, alchbiome);
                     }
                 }
-                updateMapCost();
             }
+            updateMapCost();
+        }
 	    if (Rshouldshipfarm && !Rshouldtimefarm && !Rshouldtributefarm && !Rshoulddoquest && !Rshouldequipfarm) {
 		var shipfragcheck = true;
 		if (getPageSetting('Rshipfarmfrag') == true) {

--- a/modules/maps.js
+++ b/modules/maps.js
@@ -2246,62 +2246,62 @@ function RautoMap() {
                 updateMapCost();
             }
         if (Rshouldalchfarm && !Rshouldtimefarm && !Rshouldtributefarm && !Rshoulddoquest && !Rshouldequipfarm && !Rshouldshipfarm) {
-            var alchfragcheck = true;
-            if (getPageSetting('Ralchfarmfrag') == true) {
-                if (alchfrag() == true) {
-                    alchfragcheck = true;
-                    Ralchfragfarming = false;
-                } else if (alchfrag() == false && Rshouldalchfarm) {
-                    Ralchfragfarming = true;
-                    alchfragcheck = false;
-                    if (!alchfragcheck && alchfragmappy == undefined && !alchfragmappybought && game.global.preMapsActive && Rshouldalchfarm) {
-                        debug("Check complete for alch frag map");
-                        alchfragmap();
-                        if ((updateMapCost(true) <= game.resources.fragments.owned)) {
-                            buyMap();
-                            alchfragmappybought = true;
-                            if (alchfragmappybought) {
-                                alchfragmappy = game.global.mapsOwnedArray[game.global.mapsOwnedArray.length - 1].id;
-                                debug("alch frag map bought");
+		var alchfragcheck = true;
+		if (getPageSetting('Ralchfarmfrag') == true) {
+                    if (alchfrag() == true) {
+                        alchfragcheck = true;
+                        Ralchfragfarming = false;
+                    } else if (alchfrag() == false && Rshouldalchfarm) {
+                        Ralchfragfarming = true;
+                        alchfragcheck = false;
+                        if (!alchfragcheck && alchfragmappy == undefined && !alchfragmappybought && game.global.preMapsActive && Rshouldalchfarm) {
+                            debug("Check complete for alch frag map");
+                            alchfragmap();
+                            if ((updateMapCost(true) <= game.resources.fragments.owned)) {
+                                buyMap();
+                                alchfragmappybought = true;
+                                if (alchfragmappybought) {
+                                    alchfragmappy = game.global.mapsOwnedArray[game.global.mapsOwnedArray.length - 1].id;
+                                    debug("alch frag map bought");
+                                }
                             }
                         }
-                    }
-                    if (!alchfragcheck && game.global.preMapsActive && !game.global.mapsActive && alchfragmappybought && alchfragmappy != undefined && Rshouldalchfarm) {
-                        debug("running alch frag map");
-                        selectedMap = alchfragmappy;
-                        selectMap(alchfragmappy);
-                        runMap();
-                        RlastMapWeWereIn = getCurrentMapObject();
-                        alchprefragmappy = alchfragmappy;
-                        alchfragmappy = undefined;
-                    }
-                    if (!alchfragcheck && game.global.mapsActive && alchfragmappybought && alchprefragmappy != undefined && Rshouldalchfarm) {
-                        if (alchfrag() == false) {
-                            if (!game.global.repeatMap) {
-                                repeatClicked();
-                            }
-                        } else if (alchfrag() == true) {
-                            if (game.global.repeatMap) {
-                                repeatClicked();
-                                mapsClicked();
-                            }
-                            if (game.global.preMapsActive && alchfragmappybought && alchprefragmappy != undefined && Rshouldalchfarm) {
-                                alchfragmappybought = false;
-                            }
-                            if (alchprefragmappy != undefined) {
-                                recycleMap(getMapIndex(alchprefragmappy));
-                                alchprefragmappy = undefined;
-                            }
-                            alchfragcheck = true;
-                            Ralchfragfarming = false;
+                        if (!alchfragcheck && game.global.preMapsActive && !game.global.mapsActive && alchfragmappybought && alchfragmappy != undefined && Rshouldalchfarm) {
+                            debug("running alch frag map");
+                            selectedMap = alchfragmappy;
+                            selectMap(alchfragmappy);
+                            runMap();
+                            RlastMapWeWereIn = getCurrentMapObject();
+                            alchprefragmappy = alchfragmappy;
+                            alchfragmappy = undefined;
                         }
+                        if (!alchfragcheck && game.global.mapsActive && alchfragmappybought && alchprefragmappy != undefined && Rshouldalchfarm) {
+                            if (alchfrag() == false) {
+                                if (!game.global.repeatMap) {
+                                    repeatClicked();
+                                }
+                            } else if (alchfrag() == true) {
+                                if (game.global.repeatMap) {
+                                    repeatClicked();
+                                    mapsClicked();
+                                }
+                                if (game.global.preMapsActive && alchfragmappybought && alchprefragmappy != undefined && Rshouldalchfarm) {
+                                    alchfragmappybought = false;
+                                }
+                                if (alchprefragmappy != undefined) {
+                                    recycleMap(getMapIndex(alchprefragmappy));
+                                    alchprefragmappy = undefined;
+                                }
+                                alchfragcheck = true;
+                                Ralchfragfarming = false;
+                            }
+                        }
+                    } else {
+                        alchfragcheck = true;
+                        Ralchfragfarming = false;
                     }
-                } else {
-                    alchfragcheck = true;
-                    Ralchfragfarming = false;
                 }
-            }
-            if (alchfragcheck && getPageSetting('Ralchfarmlevel') != 0) {
+                if (alchfragcheck && getPageSetting('Ralchfarmlevel') != 0) {
                 if (alchfarmzone.includes(game.global.world)) {
                     if (Rshouldalchfarm) {
                 

--- a/modules/other.js
+++ b/modules/other.js
@@ -3755,8 +3755,8 @@ function alchfragmap() {
     }
 }
 
-function alchfragmin(number, selection) {
-    document.getElementById("biomeAdvMapsSelect").value = selection;
+function alchfragmin(number, biome) {
+    document.getElementById("biomeAdvMapsSelect").value = biome;
     document.getElementById("advExtraLevelSelect").value = number;
     document.getElementById("advSpecialSelect").value = "fa";
     document.getElementById("lootAdvMapsRange").value = 9;
@@ -3800,23 +3800,14 @@ function alchfrag() {
 		
 	    var alchfarmzone = getPageSetting('Ralchfarmzone');
             var alchfarmlevel = getPageSetting('Ralchfarmlevel');
-	    var alchfarmselection = getPageSetting('Ralchfarmselection').split(',');
 
             var alchfarmlevelindex = alchfarmzone.indexOf(game.global.world);
             var alchlevelzones = alchfarmlevel[alchfarmlevelindex];
-            var alchfarmselectionindex = alchfarmzone.indexOf(game.global.world);
-            var selection = alchfarmselection[alchfarmselectionindex];
-	    if (selection == 'm') selection = "Mountain";
-            else if (selection == 'f') selection = "Forest";
-            else if (selection == 's') selection = "Sea";
-            else if (selection == 'd') selection = "Depths";
-            else if (selection == 'g') selection = "Plentiful";
-            else if (selection == 'l') selection = "Farmlands";
 
-	    alchfragmin(alchlevelzones, selection);
+	    alchfragmin(alchlevelzones, alchbiome);
 		
 	    if (getPageSetting('Ralchfarmfrag') == true) {
-		cost = alchfragmin(alchlevelzones, selection);
+		cost = alchfragmin(alchlevelzones, alchbiome);
 	    }
 
 	    if (game.resources.fragments.owned >= cost) return true;


### PR DESCRIPTION
Adjusted the alch farm code slightly to automatically select the appropriate biome for the zone you're on and will use regular maps if farmlands is yet to be unlocked. Figured it was worth doing a PR as a few people have had issues with the setting. Also provides an error msg if somebody has an incorrect input in their potions to make it easier for them to fix their issue.

Had to change your implementation slightly as it was easier to just copy paste the code I'd written for it than try and change it to match your code but I tested it and it seems to function properly.