### PR TITLE
Potential fix for Prestige resetting randomly

### DIFF
--- a/SettingsGUI.js
+++ b/SettingsGUI.js
@@ -1238,8 +1238,13 @@ function settingChanged(id) {
     }
     if (btn.type == 'dropdown') {
         btn.selected = document.getElementById(id).value;
-        if (id == "Prestige")
-            autoTrimpSettings["PrestigeBackup"].selected = document.getElementById(id).value;
+        if (id == "Prestige") {
+            autoTrimpSettings["PrestigeBackup"] = {
+              selected: document.getElementById(id).value,
+              name: "PrestigeBackup",
+              id: "PrestigeBackup"
+            };
+        }
     }
     updateCustomButtons();
     saveSettings();


### PR DESCRIPTION
This PR fixes an issue where changing the Prestige setting causes the indexing of a possibly undefined "PrestigeBackup" setting. I'm not sure if "PrestigeBackup" is still used, but this is a quick fix to stop an error that might be causing settings to get into a weird state after changing Prestige.