### PR TITLE
Zek fork further Experience support

### DIFF
--- a/SettingsGUI.js
+++ b/SettingsGUI.js
@@ -622,6 +622,8 @@ function initializeAllSettings() {
     createSetting('buywepsvoid', 'VM Buy Weps', 'Buys gear in Void maps regardless of your H:D ratio. Useful if you want to overkill as much as possible. ', 'boolean', false, null, 'Maps');
     createSetting('farmWonders', 'Farm Wonders', 'Farms wonders until the selected amount and does BW at given zone to finish the challenge', 'boolean', false, null, 'Maps')
     createSetting('wondersAmount', 'Wonders Amount', 'Select the amount of Wonders you want to farm in each given run, <b> 0 to disable </b>', 'value', '0', null, "Maps");
+    createSetting('maxExpZone', "Max XP Zone", 'Acquire Wonders from this zone down. If >z600, will complete Experience by running BW on this zone as well. For example, targeting three Wonders with a Max XP Zone of 600 will obtain the Wonders at: 600, 595, 590.', 'value', '600', null, 'Maps');
+    createSetting('finishExpOnBw', 'Finish XP on BW', 'Finish Experience challenge by completing this level of BW. <b>This level of BW should already be in your inventory.</b> Use BW Raiding module if you want to raid to a specific level of BW before 601, or else you may accidentally complete the challenge at a lower or higher BW than intended using this setting.', 'value', '605', null, 'Maps');
 
     //RMaps
 

--- a/SettingsGUI.js
+++ b/SettingsGUI.js
@@ -623,7 +623,7 @@ function initializeAllSettings() {
     createSetting('farmWonders', 'Farm Wonders', 'Farms wonders until the selected amount and does BW at given zone to finish the challenge', 'boolean', false, null, 'Maps')
     createSetting('wondersAmount', 'Wonders Amount', 'Select the amount of Wonders you want to farm in each given run, <b> 0 to disable </b>', 'value', '0', null, "Maps");
     createSetting('maxExpZone', "Max XP Zone", 'Acquire Wonders from this zone down. If >z600, will complete Experience by running BW on this zone as well. For example, targeting three Wonders with a Max XP Zone of 600 will obtain the Wonders at: 600, 595, 590.', 'value', '600', null, 'Maps');
-    createSetting('finishExpOnBw', 'Finish XP on BW', 'Finish Experience challenge by completing this level of BW. <b>This level of BW should already be in your inventory.</b> Use BW Raiding module if you want to raid to a specific level of BW before 601, or else you may accidentally complete the challenge at a lower or higher BW than intended using this setting.', 'value', '605', null, 'Maps');
+    createSetting('finishExpOnBw', 'Finish XP on BW', 'Finish Experience challenge by completing this level of BW. <b>This level of BW should already be in your inventory.</b> Use BW Raiding module if you want to raid to a specific level of BW before 601, or else you may accidentally complete the challenge at a lower or higher BW than intended using this setting. If this is an invalid BW value, it will run the next lowest valid BW zone (e.g. 606 will run 605).', 'value', '605', null, 'Maps');
 
     //RMaps
 

--- a/SettingsGUI.js
+++ b/SettingsGUI.js
@@ -1845,9 +1845,9 @@ function updateCustomButtons() {
     !radonon ? turnOn("scryvoidmaps") : turnOff("scryvoidmaps");
     !radonon ? turnOn("buywepsvoid") : turnOff("buywepsvoid");
     !radonon ? turnOn("farmWonders") : turnOff("farmWonders");
-    !radonon ? turnOn("wondersAmount") : turnOff("wondersAmount");
-    !radonon ? turnOn("maxExpZone") : turnOff("maxExpZone");
-    !radonon ? turnOn("finishExpOnBw") : turnOff("finishExpOnBw");
+    (!radonon && getPageSetting("farmWonders")) ? turnOn("wondersAmount") : turnOff("wondersAmount");
+    (!radonon && getPageSetting("farmWonders")) ? turnOn("maxExpZone") : turnOff("maxExpZone");
+    (!radonon && getPageSetting("farmWonders")) ? turnOn("finishExpOnBw") : turnOff("finishExpOnBw");
 
     //RMaps
     radonon ? turnOn("RAutoMaps") : turnOff("RAutoMaps");

--- a/SettingsGUI.js
+++ b/SettingsGUI.js
@@ -1842,8 +1842,10 @@ function updateCustomButtons() {
     !radonon ? turnOn("AdvMapSpecialModifier") : turnOff("AdvMapSpecialModifier");
     !radonon ? turnOn("scryvoidmaps") : turnOff("scryvoidmaps");
     !radonon ? turnOn("buywepsvoid") : turnOff("buywepsvoid");
-    game.global.highestLevelCleared > 600 && !radonon ? turnOn("farmWonders") : turnOff("farmWonders");
-    game.global.highestLevelCleared > 600 && !radonon ? turnOn("wondersAmount") : turnOff("wondersAmount");
+    !radonon ? turnOn("farmWonders") : turnOff("farmWonders");
+    !radonon ? turnOn("wondersAmount") : turnOff("wondersAmount");
+    !radonon ? turnOn("maxExpZone") : turnOff("maxExpZone");
+    !radonon ? turnOn("finishExpOnBw") : turnOff("finishExpOnBw");
 
     //RMaps
     radonon ? turnOn("RAutoMaps") : turnOff("RAutoMaps");

--- a/SettingsGUI.js
+++ b/SettingsGUI.js
@@ -622,7 +622,7 @@ function initializeAllSettings() {
     createSetting('buywepsvoid', 'VM Buy Weps', 'Buys gear in Void maps regardless of your H:D ratio. Useful if you want to overkill as much as possible. ', 'boolean', false, null, 'Maps');
     createSetting('farmWonders', 'Farm Wonders', 'Farms wonders until the selected amount and does BW at given zone to finish the challenge', 'boolean', false, null, 'Maps')
     createSetting('wondersAmount', 'Wonders Amount', 'Select the amount of Wonders you want to farm in each given run, <b> 0 to disable </b>', 'value', '0', null, "Maps");
-    createSetting('maxExpZone', "Max XP Zone", 'Acquire Wonders from this zone down. If >z600, will complete Experience by running BW on this zone as well. For example, targeting three Wonders with a Max XP Zone of 600 will obtain the Wonders at: 600, 595, 590.', 'value', '600', null, 'Maps');
+    createSetting('maxExpZone', "Max XP Zone", 'Acquire Wonders from this zone down. <b>This must have a value or other Experience settings will not work.</b> If >z600, will complete Experience by running BW on this zone as well. For example, targeting three Wonders with a Max XP Zone of 600 will obtain the Wonders at: 600, 595, 590.', 'value', '600', null, 'Maps');
     createSetting('finishExpOnBw', 'Finish XP on BW', 'Finish Experience challenge by completing this level of BW. <b>This level of BW should already be in your inventory.</b> Use BW Raiding module if you want to raid to a specific level of BW before 601, or else you may accidentally complete the challenge at a lower or higher BW than intended using this setting. If this is an invalid BW value, it will run the next lowest valid BW zone (e.g. 606 will run 605).', 'value', '605', null, 'Maps');
 
     //RMaps

--- a/modules/maps.js
+++ b/modules/maps.js
@@ -797,9 +797,6 @@ function autoMap() {
             var pageSetting = getPageSetting('finishExpOnBw');
             pageSetting = pageSetting < 125 ? 125 : pageSetting;
             pageSetting = pageSetting != -1 ? (Math.floor((pageSetting - 125) / 15) * 15) + 125 : -1;
-            if (pageSetting != getPageSetting('finishExpOnBw')){
-                debug("Invalid BW number detected to finish XP on BW: " + getPageSetting('finishExpOnBw') + ". Set to nearest lowest BW, " + pageSetting + ".");
-            }
             return pageSetting;
         })();
         var bionics = game.global.mapsOwnedArray

--- a/modules/maps.js
+++ b/modules/maps.js
@@ -836,7 +836,8 @@ function autoMap() {
                     }
                 }
             }
-        } else if (game.global.world > 600 && !game.global.mapsActive && game.global.world != 700 && game.global.world >= wondersFromZ && finishOnBw != -1) {
+        } else if (game.global.world > 600 && !game.global.mapsActive && game.global.world != 700
+            && wondersFromZ != -1 && game.global.world >= wondersFromZ && finishOnBw != -1) {
             // Finish challenge with target BW. If for some reason we've raided past it, pick the lowest BW available.
             // If we somehow did not raid for it, pick the highest available which will climb if necessary to 605.
             // If at 700, clear the zone to complete instead.

--- a/modules/maps.js
+++ b/modules/maps.js
@@ -28,7 +28,7 @@ var spireMapBonusFarming = !1;
 var spireTime = 0;
 var doMaxMapBonus = !1;
 var vanillaMapatZone = !1;
-var shouldFarmWonder = false;
+var farmingWonder = !1;
 var additionalCritMulti = 2 < getPlayerCritChance() ? 25 : 5;
 
 function updateAutoMapsStatus(get) {
@@ -64,6 +64,7 @@ function updateAutoMapsStatus(get) {
     else if (!enoughHealth && !enoughDamage) status = 'Want Health & Damage';
     else if (!enoughDamage) status = 'Want ' + calcHDratio().toFixed(4) + 'x &nbspmore damage';
     else if (!enoughHealth) status = 'Want more health';
+    else if (farmingWonder) status = 'Experiencing Wonder';
     else if (enoughHealth && enoughDamage) status = 'Advancing';
 
     if (skippedPrestige)


### PR DESCRIPTION
This should keep your fork content-complete for U1.

Added further support for Experience challenge:
* Now gathers X Wonders from highest possible zone rather than lowest to maximize XP gains
* Adds support to finish Experience challenge by running BW XXX on zXX

Open to making the tooltip descriptions less confusing, I probably use many word when less word do trick.