### PR TITLE
Feat: Automatically Use Bone Charges When Maxed

### DIFF
--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -161,6 +161,9 @@ function mainLoop() {
     if (game.global.world != autoTrimpSettings.zonetracker) {
         autoTrimpSettings.zonetracker = game.global.world;
     }
+    
+    //Universal Logic
+    if (getPageSetting('AutoBoneChargeMax') != 0) autoBoneChargeWhenMax();
 
     //Logic for Universe 1
     if (game.global.universe == 1) {

--- a/SettingsGUI.js
+++ b/SettingsGUI.js
@@ -285,6 +285,8 @@ function initializeAllSettings() {
     createSetting('fastallocate', 'Fast Allocate', 'Turn on if your helium is above 500Qa. Not recommended for low amounts of helium. ', 'boolean', false, null, 'Core');
     createSetting('TrapTrimps', 'Trap Trimps', 'Automatically trap trimps when needed, including building traps. (when you turn this off, you may aswell turn off the in-game autotraps button, think of the starving trimps that could eat that food!)', 'boolean', true, null, "Core");
     createSetting('AutoEggs', 'AutoEggs', 'Click easter egg if it exists, upon entering a new zone. Warning: Quite overpowered. Please solemnly swear that you are up to no good.', 'boolean', false, null, 'Core');
+    createSetting('AutoBoneChargeMax', ['Manual Bone Charge', 'Bone Charge When Max', 'Bone Charge (Daily Only)'], 'Automatically uses a Bone Charge from the Bone Shrine if you are at max charges. The start zone can be configured under <i>Bone Charge Start Z.</i><br><br><b>Bone Charge (Daily Only)</b> as the name suggests; will only use a Bone Charge when at max and if on a daily challenge.<br><br><b>Default: Off (Manual Bone Charge).</b>', 'multitoggle', 0, null, "Core");
+    createSetting('AutoBoneChargeMaxStartZone', 'Bone Charge Start Z', 'Enter the zone number at which you wish to <i>start</i> using Bone Charges.<br><br>Alternatively, set it to <i><b>-1</b></i> to automatically update the zone to 10% of your highest zone cleared. For example, if your highest zone cleared was 400, bone charges would be automatically used from zone 360 onwards.<br><br><b>Default: Automated (-1).</b>', 'value', -1, null, "Core");
     document.getElementById('AutoEggs').parentNode.insertAdjacentHTML('afterend', '<br>');
 
     //RCore
@@ -1569,6 +1571,8 @@ function updateCustomButtons() {
 
     //Radon
     var radonon = getPageSetting('radonsettings') == 1;
+    //Bone Shrine
+    var boneShrinePurchased = game.permaBoneBonuses.boosts.owned > 0 ? true : false;
 
     //Tabs
     if (document.getElementById("tabSpire") != null) {
@@ -1609,6 +1613,8 @@ function updateCustomButtons() {
     !radonon && getPageSetting('amalcoord') == true ? turnOn("amalcoordz") : turnOff("amalcoordz");
     !radonon ? turnOn("AutoAllocatePerks") : turnOff("AutoAllocatePerks");
     !radonon && getPageSetting('AutoAllocatePerks') == 1 ? turnOn("fastallocate") : turnOff("fastallocate");
+    boneShrinePurchased ? turnOn('AutoBoneChargeMax') : turnOff("AutoBoneChargeMax");
+    boneShrinePurchased ? turnOn("AutoBoneChargeMaxStartZone") : turnOff("AutoBoneChargeMaxStartZone");
 
     //Portal
     !radonon ? turnOn("AutoPortal") : turnOff("AutoPortal");

--- a/modules/other.js
+++ b/modules/other.js
@@ -4152,3 +4152,41 @@ nextWorld = function() {
     autoTrimpSettings.Rshrinecharge.value = 0;
     return retVal;
 }
+
+function autoBoneChargeWhenMax() {
+  // Uses bone charges when they are at max charges automatically.
+
+  // If "Daily Only" was chosen and we're not on a daily challenge, exit.
+  if (
+    getPageSetting("AutoBoneChargeMax") === 2 &&
+    !(game.global.challengeActive == "Daily")
+  ) {
+    return;
+  }
+
+  // If the option is enabled but no zone is specified, set a default value to
+  // the highest zone cleared - 10% or 60 (broken planet equipment discount)
+  // if the HZC value would be less than 60. Otherwise use the user value.
+  const autoBoneChargeEnabled =
+    getPageSetting("AutoBoneChargeMax") > 0 ? true : false;
+  const autoBoneChargeZoneSet =
+    getPageSetting("AutoBoneChargeMaxStartZone") > 0 ? true : false;
+  const highestZoneCleared = game.global.highestLevelCleared;
+  const percentOfHZC = Math.round((10 / 100) * highestZoneCleared);
+  const optimalChargeZone =
+    highestZoneCleared - percentOfHZC > 60
+      ? highestZoneCleared - percentOfHZC
+      : 60;
+  const chargeZone = !autoBoneChargeZoneSet
+    ? optimalChargeZone
+    : autoTrimpSettings.AutoBoneChargeMaxStartZone.value;
+  const boneChargesAvailable = game.permaBoneBonuses.boosts.charges;
+  const currentZone = game.global.world;
+
+  // If we have more than 10 bone charges and our current world zone is
+  // greater than or equal to the charge zone set; use a bone charge.
+  if (boneChargesAvailable === 10 && currentZone >= chargeZone) {
+    game.permaBoneBonuses.boosts.consume();
+    debug("Max bone charges reached! Used a bone charge.", "general", "*bolt");
+  }
+}


### PR DESCRIPTION
This adds a new feature that can be turned on allowing automatic use of bone charges when they are maxed to prevent them from being wasted.

It supports both Helium (U1) and Radon (U2) universes, has an option to toggle it on just for dailies, and you are also able to specify the start zone. If no zone is specified it will automatically calculate 10% of your highest zone cleared and start using bone charges from that zone onwards.