### PR TITLE
FIX: Update Championism perk exprate to 5

### DIFF
--- a/modules/perks.js
+++ b/modules/perks.js
@@ -1375,6 +1375,7 @@ RAutoPerks.initializePerks = function () {
     var championism = new RAutoPerks.VariablePerk("championism", 1000000000, true,      14, 0.1);
     
     equality.exprate = 1.5;
+    championism.exprate = 5;
     //scruffy
 	//no
     //tier2


### PR DESCRIPTION
Trying to allocate perks while having Championism has errors, it thinks the exp rate is 1.3 instead of 5 so it tries to buy too many of the perk and ends up keeping the perk at 0 while leaving all of the Radon unallocated. This should correctly fix the exprate for Championism to 5 so it correctly calculates and purchases the right amount.