### PR TITLE
Graphs-Only upgrades

### DIFF
--- a/GraphsOnly.js
+++ b/GraphsOnly.js
@@ -62,6 +62,7 @@ var $u1Graph = document.getElementById("graphFooterLine1"),
         "Fluffy XP",
         "Fluffy XP PerHour",
         "Amalgamators",
+        "Wonders",
     ],
     $u1graphSel = document.createElement("select");
 for (var item in (($u1graphSel.id = "u1graphSelection"), $u1graphSel.setAttribute("style", ""), $u1graphSel.setAttribute("onchange", "drawGraph()"), u1graphList)) {
@@ -330,6 +331,7 @@ function pushData() {
         worshippers: game.jobs.Worshipper.owned,
         bonfires: game.challenges.Hypothermia.bonfires,
         embers: game.challenges.Hypothermia.embers,
+        wonders: game.challenges.Experience.wonders,
         universe: game.global.universe,
         universeSelection: document.getElementById('universeSelection').options[document.getElementById('universeSelection').options.selectedIndex].value,
         u1graphSelection: document.getElementById('u1graphSelection').options[document.getElementById('u1graphSelection').options.selectedIndex].value,
@@ -343,19 +345,26 @@ function pushData() {
 function showHideUnusedGraphs() {
     // Hide challenge graphs that are not in the saved data
     const graphedChallenges = [...new Set(allSaveData.map((data) => data = data.challenge))];
-    const perChallengeGraphs = {Hypothermia: ["Bonfires", "Embers"]};
-    for (const [challenge, graphs] of Object.entries(perChallengeGraphs)) {
+    const perChallengeGraphs = {Hypothermia: {graphs: ["Bonfires", "Embers"], universe: "u2"},
+                                Experience: {graphs: ["Wonders"], universe: "u1"}};
+    for (const [challenge, data] of Object.entries(perChallengeGraphs)) {
+        const graphs = data.graphs;
         const style = graphedChallenges.includes(challenge) ? "" : "none";
-        graphs.forEach((graph) => { document.querySelector(`#u2graphSelection [value=${graph}]`).style.display = style; })
+        graphs.forEach((graph) => { document.querySelector(`#${data.universe}graphSelection [value=${graph}]`).style.display = style; })
     }
     // Hide specific graphs that are constant (either not unlocked yet, or maxed)
-    const emptyGraphs = {"u2": [["OverkillCells", "overkill"], ["Worshippers", "worshippers"]], 
-                         "u1": [["OverkillCells", "overkill"], ["Fluffy XP", "fluffy"], ["Fluffy XP PerHour", "fluffy"], ["Amalgamators", "amals"]]};
-    for (const [universe, graphs] of Object.entries(emptyGraphs)) {
-        for (const [graphName, dataName] of graphs) {
-            const style = [...new Set(allSaveData.map((data) => data = data[dataName]))].length == 1 ? "none" : "";
-            document.querySelector(`#${universe}graphSelection [value="${graphName}"]`).style.display = style;
-        }
+    const emptyGraphs = {OverkillCells: {dataName: "overkill", universe: "u1"},
+                         OverkillCells: {dataName: "overkill", universe: "u2"},
+                         Worshippers: {universe: "u2"}, 
+                         "Fluffy XP": {dataName: "fluffy", universe: "u1"}, 
+                         "Fluffy XP PerHour": {dataName: "fluffy", universe: "u1"},
+                         Amalgamators: {dataName: "amals", universe: "u1"}, 
+                         }
+    for (const [graphName, data] of Object.entries(emptyGraphs)) {
+        const dataName = data.dataName ? data.dataName : graphName.toLowerCase();
+        const style = [...new Set(allSaveData.map((graphs) => graphs = graphs[dataName]))].length == 1 ? "none" : "";
+        document.querySelector(`#${data.universe}graphSelection [value="${graphName}"]`).style.display = style;
+        
     }
 }
 
@@ -890,13 +899,6 @@ function setGraphData(graph) {
             yType = "Linear";
             xminFloor = 1;
             break;
-        case "Smithies":
-            graphData = allPurposeGraph("smithies", true, "number");
-            title = "Smithy History";
-            xTitle = "Zone";
-            yTitle = "Smithies";
-            yType = "Linear";
-            break;
         case "OverkillCells":
             var currentPortal = -1;
             graphData = [];
@@ -928,25 +930,11 @@ function setGraphData(graph) {
             yTitle = "Overkilled Cells";
             yType = "Linear";
             break;   
-        case "Worshippers":
-            graphData = allPurposeGraph("worshippers", true, "number");
-            title = "Worshipper History";
+        default:
+            graphData = allPurposeGraph(graph.toLowerCase(), true, "number");
+            title = `${graph} History`;
             xTitle = "Zone";
-            yTitle = "Worshippers";
-            yType = "Linear";
-            break;
-        case "Embers":
-            graphData = allPurposeGraph("embers", true, "number");
-            title = "Ember History";
-            xTitle = "Zone";
-            yTitle = "Embers";
-            yType = "Linear";
-            break;
-        case "Bonfires":
-            graphData = allPurposeGraph("bonfires", true, "number");
-            title = "Bonfire History";
-            xTitle = "Zone";
-            yTitle = "Bonfires";
+            yTitle = graph;
             yType = "Linear";
             break;
     }

--- a/GraphsOnly.js
+++ b/GraphsOnly.js
@@ -85,8 +85,14 @@ var $u2Graph = document.getElementById("graphFooterLine1"),
         "Smithies",
         "Scruffy XP",
         "Scruffy XP PerHour",
+        "Worshippers",
+        "Bonfires",
+        "Embers",
     ],
     $u2graphSel = document.createElement("select");
+/* TODO Modify this to filter out graphs that are for challenges not in the current history
+ * Will require an update to this selector whenever a new portal is started
+*/
 for (var item in (($u2graphSel.id = "u2graphSelection"), $u2graphSel.setAttribute("style", ""), $u2graphSel.setAttribute("onchange", "drawGraph()"), u2graphList)) {
     var $opt = document.createElement("option");
     ($opt.value = u2graphList[item]), ($opt.text = u2graphList[item]), $u2graphSel.appendChild($opt);
@@ -321,6 +327,9 @@ function pushData() {
         rnhr: RgetPercent.toFixed(4),
         rnlife: Rlifetime.toFixed(4),
 		s3: game.global.lastRadonPortal,
+        worshippers: game.jobs.Worshipper.owned,
+        bonfires: game.challenges.Hypothermia.bonfires,
+        embers: game.challenges.Hypothermia.embers,
         universe: game.global.universe,
         universeSelection: document.getElementById('universeSelection').options[document.getElementById('universeSelection').options.selectedIndex].value,
         u1graphSelection: document.getElementById('u1graphSelection').options[document.getElementById('u1graphSelection').options.selectedIndex].value,
@@ -897,6 +906,27 @@ function setGraphData(graph) {
             title = "Overkilled Cells";
             xTitle = "Zone";
             yTitle = "Overkilled Cells";
+            yType = "Linear";
+            break;   
+        case "Worshippers":
+            graphData = allPurposeGraph("worshippers", true, "number");
+            title = "Worshipper History";
+            xTitle = "Zone";
+            yTitle = "Worshippers";
+            yType = "Linear";
+            break;
+        case "Embers":
+            graphData = allPurposeGraph("embers", true, "number");
+            title = "Ember History";
+            xTitle = "Zone";
+            yTitle = "Embers";
+            yType = "Linear";
+            break;
+        case "Bonfires":
+            graphData = allPurposeGraph("bonfires", true, "number");
+            title = "Bonfire History";
+            xTitle = "Zone";
+            yTitle = "Bonfires";
             yType = "Linear";
             break;
     }

--- a/GraphsOnly.js
+++ b/GraphsOnly.js
@@ -307,7 +307,7 @@ function pushData() {
         voids: game.global.totalVoidMaps,
         heirlooms: { value: game.stats.totalHeirlooms.value, valueTotal: game.stats.totalHeirlooms.valueTotal },
         nullifium: recycleAllExtraHeirlooms(true),
-        coord: game.upgrades.Coordination.done,
+        coord: game.upgrades.Coordination.allowed - game.upgrades.Coordination.done,
         lastwarp: game.global.lastWarp,
         essence: getTotalDarkEssenceCount(),
         heliumOwned: game.resources.helium.owned,
@@ -341,11 +341,21 @@ function pushData() {
 }
 
 function showHideUnusedGraphs() {
+    // Hide challenge graphs that are not in the saved data
     const graphedChallenges = [...new Set(allSaveData.map((data) => data = data.challenge))];
     const perChallengeGraphs = {Hypothermia: ["Bonfires", "Embers"]};
     for (const [challenge, graphs] of Object.entries(perChallengeGraphs)) {
         const style = graphedChallenges.includes(challenge) ? "" : "none";
         graphs.forEach((graph) => { document.querySelector(`#u2graphSelection [value=${graph}]`).style.display = style; })
+    }
+    // Hide specific graphs that are constant (either not unlocked yet, or maxed)
+    const emptyGraphs = {"u2": [["OverkillCells", "overkill"], ["Worshippers", "worshippers"]], 
+                         "u1": [["OverkillCells", "overkill"], ["Fluffy XP", "fluffy"], ["Fluffy XP PerHour", "fluffy"], ["Amalgamators", "amals"]]};
+    for (const [universe, graphs] of Object.entries(emptyGraphs)) {
+        for (const [graphName, dataName] of graphs) {
+            const style = [...new Set(allSaveData.map((data) => data = data[dataName]))].length == 1 ? "none" : "";
+            document.querySelector(`#${universe}graphSelection [value="${graphName}"]`).style.display = style;
+        }
     }
 }
 
@@ -786,7 +796,7 @@ function setGraphData(graph) {
             break;
         case "Coordinations":
             graphData = allPurposeGraph("coord", true, "number");
-            title = "Coordination History";
+            title = "Unpurchased Coordinations History";
             xTitle = "Zone";
             yTitle = "Coordination";
             yType = "Linear";

--- a/GraphsOnly.js
+++ b/GraphsOnly.js
@@ -63,6 +63,7 @@ var $u1Graph = document.getElementById("graphFooterLine1"),
         "Fluffy XP PerHour",
         "Amalgamators",
         "Wonders",
+        "Empower",
     ],
     $u1graphSel = document.createElement("select");
 for (var item in (($u1graphSel.id = "u1graphSelection"), $u1graphSel.setAttribute("style", ""), $u1graphSel.setAttribute("onchange", "drawGraph()"), u1graphList)) {
@@ -89,6 +90,8 @@ var $u2Graph = document.getElementById("graphFooterLine1"),
         "Worshippers",
         "Bonfires",
         "Embers",
+        "Cruffys",
+        "Empower"
     ],
     $u2graphSel = document.createElement("select");
 for (var item in (($u2graphSel.id = "u2graphSelection"), $u2graphSel.setAttribute("style", ""), $u2graphSel.setAttribute("onchange", "drawGraph()"), u2graphList)) {
@@ -332,6 +335,8 @@ function pushData() {
         bonfires: game.challenges.Hypothermia.bonfires,
         embers: game.challenges.Hypothermia.embers,
         wonders: game.challenges.Experience.wonders,
+        empower: game.global.dailyChallenge?.empower?.stacks,
+        cruffys: game.challenges.Nurture.level,
         universe: game.global.universe,
         universeSelection: document.getElementById('universeSelection').options[document.getElementById('universeSelection').options.selectedIndex].value,
         u1graphSelection: document.getElementById('u1graphSelection').options[document.getElementById('u1graphSelection').options.selectedIndex].value,
@@ -346,6 +351,7 @@ function showHideUnusedGraphs() {
     // Hide challenge graphs that are not in the saved data
     const graphedChallenges = [...new Set(allSaveData.map((data) => data = data.challenge))];
     const perChallengeGraphs = {Hypothermia: {graphs: ["Bonfires", "Embers"], universe: "u2"},
+                                Nurture: {graphs: ["Cruffys"], universe: "u2"},
                                 Experience: {graphs: ["Wonders"], universe: "u1"}};
     for (const [challenge, data] of Object.entries(perChallengeGraphs)) {
         const graphs = data.graphs;
@@ -353,17 +359,20 @@ function showHideUnusedGraphs() {
         graphs.forEach((graph) => { document.querySelector(`#${data.universe}graphSelection [value=${graph}]`).style.display = style; })
     }
     // Hide specific graphs that are constant (either not unlocked yet, or maxed)
-    const emptyGraphs = {OverkillCells: {dataName: "overkill", universe: "u1"},
-                         OverkillCells: {dataName: "overkill", universe: "u2"},
+    const emptyGraphs = {OverkillCells: {dataName: "overkill"},
                          Worshippers: {universe: "u2"}, 
                          "Fluffy XP": {dataName: "fluffy", universe: "u1"}, 
                          "Fluffy XP PerHour": {dataName: "fluffy", universe: "u1"},
                          Amalgamators: {dataName: "amals", universe: "u1"}, 
+                         Empower: {},
                          }
     for (const [graphName, data] of Object.entries(emptyGraphs)) {
         const dataName = data.dataName ? data.dataName : graphName.toLowerCase();
-        const style = [...new Set(allSaveData.map((graphs) => graphs = graphs[dataName]))].length == 1 ? "none" : "";
-        document.querySelector(`#${data.universe}graphSelection [value="${graphName}"]`).style.display = style;
+        const universes = data.universe ? [data.universe] : ["u1", "u2"]
+        for (universe of universes) {
+            const style = [...new Set(allSaveData.map((graphs) => graphs = graphs[dataName]))].length == 1 ? "none" : "";
+            document.querySelector(`#${universe}graphSelection [value="${graphName}"]`).style.display = style;
+        }
         
     }
 }

--- a/GraphsOnly.js
+++ b/GraphsOnly.js
@@ -90,9 +90,6 @@ var $u2Graph = document.getElementById("graphFooterLine1"),
         "Embers",
     ],
     $u2graphSel = document.createElement("select");
-/* TODO Modify this to filter out graphs that are for challenges not in the current history
- * Will require an update to this selector whenever a new portal is started
-*/
 for (var item in (($u2graphSel.id = "u2graphSelection"), $u2graphSel.setAttribute("style", ""), $u2graphSel.setAttribute("onchange", "drawGraph()"), u2graphList)) {
     var $opt = document.createElement("option");
     ($opt.value = u2graphList[item]), ($opt.text = u2graphList[item]), $u2graphSel.appendChild($opt);
@@ -208,6 +205,7 @@ function loadGraphs() {
 function appendGraphs() {
     drawGraph();
 }
+
 var rememberSelectedVisible = [];
 function saveSelectedGraphs() {
     rememberSelectedVisible = [];
@@ -253,12 +251,14 @@ function clearData(portal, clrall = false) {
 
         allSaveData.splice(0, keepSaveDataIndex + 1);
     }
+    showHideUnusedGraphs();
 }
 function deleteSpecific() {
     var a = document.getElementById("deleteSpecificTextBox").value;
     if ("" != a)
         if (0 > parseInt(a)) clearData(Math.abs(a));
         else for (var b = allSaveData.length - 1; 0 <= b; b--) allSaveData[b].totalPortals == a && allSaveData.splice(b, 1);
+    showHideUnusedGraphs();
 }
 function autoToggleGraph() {
     game.options.displayed && toggleSettingsMenu();
@@ -337,6 +337,16 @@ function pushData() {
     });
     clearData(10);
     safeSetItems("allSaveData", JSON.stringify(allSaveData));
+    showHideUnusedGraphs();
+}
+
+function showHideUnusedGraphs() {
+    const graphedChallenges = [...new Set(allSaveData.map((data) => data = data.challenge))];
+    const perChallengeGraphs = {Hypothermia: ["Bonfires", "Embers"]};
+    for (const [challenge, graphs] of Object.entries(perChallengeGraphs)) {
+        const style = graphedChallenges.includes(challenge) ? "" : "none";
+        graphs.forEach((graph) => { document.querySelector(`#u2graphSelection [value=${graph}]`).style.display = style; })
+    }
 }
 
 var graphAnal = [];


### PR DESCRIPTION
New feature: Allow graphs that are not currently used (challenge graphs, capped features, locked feature...) to be hidden.
New graphs: Bonfires, Embers, Cruffys, Worshippers, Wonders, Empower.
Modified graphs: Coord shows unpurchased Coords instead of purchased.
Refactor: Default case for simple graphs.