### PR TITLE
Graphs Rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 AutoTrimps2.js
+.vscode/settings.json
+Graphs_old.js
+highcharts.src.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
 AutoTrimps2.js
-.vscode/settings.json
-Graphs_old.js
-highcharts.src.js

--- a/Graphs.js
+++ b/Graphs.js
@@ -225,7 +225,9 @@ function Graph(dataVar, universe, selectorText, additionalParams = {}) {
         type: this.yType,
         labels: {
           formatter: formatters.defaultAxis
-        }
+        },
+        endOnTick: false,
+        maxPadding: .05,
       },
       tooltip: {
         pointFormatter: this.formatter,

--- a/Graphs.js
+++ b/Graphs.js
@@ -790,7 +790,7 @@ const getGameData = {
   nullifium: () => { return recycleAllExtraHeirlooms(true) },
   coord: () => { return game.upgrades.Coordination.allowed - game.upgrades.Coordination.done },
   overkill: () => {
-    // overly complex check for Liq, overly fragile check for overkill cells
+    // overly complex check for Liq, overly fragile check for overkill cells. please rewrite this at some point.
     if (game.options.menu.overkillColor.enabled == 0) toggleSetting("overkillColor");
     if (game.options.menu.liquification.enabled && game.talents.liquification.purchased && !game.global.mapsActive && game.global.gridArray && game.global.gridArray[0] && game.global.gridArray[0].name == "Liquimp")
       return 100;
@@ -804,7 +804,14 @@ const getGameData = {
   heliumOwned: () => { return game.resources.helium.owned },
   magmite: () => { return game.global.magmite },
   magmamancers: () => { return game.jobs.Magmamancer.owned },
-  fluffy: () => { return game.global.fluffyExp },
+  fluffy: () => {
+    //sum of all previous evo costs + current exp
+    let exp = game.global.fluffyExp;
+    for (var evo = 0; evo < Fluffy.getCurrentPrestige(); evo++) {
+      exp += 111848 * 5 ** (evo + 5);
+    }
+    return exp
+  },
   nursery: () => { return game.buildings.Nursery.purchased },
   amals: () => { return game.jobs.Amalgamator.owned },
   wonders: () => { return game.challenges.Experience.wonders },

--- a/Graphs.js
+++ b/Graphs.js
@@ -304,7 +304,7 @@ function Graph(dataVar, universe, selectorText, additionalParams = {}) {
   this.columnGraph = function () {
     var highChartsObj = this.createHighChartsObj() // make default object, to be customized as needed
     highChartsObj.xAxis.title.text = "Portal"
-    highChartsObj.plotOptions.series = { groupPadding: .05, pointPadding: 0, animation: false, }
+    highChartsObj.plotOptions.series = { groupPadding: .2, pointPadding: 0, animation: false, }
     // set up axes for each column so they scale independently
     var activeColumns = this.columns.filter(column => !(column.universe && column.universe != GRAPHSETTINGS.universeSelection));
     if (GRAPHSETTINGS.toggles[this.id].perHr) { // disable time when comparing things over time.  x/x is not interesting data.
@@ -923,7 +923,7 @@ var toggledGraphs = {
   mapCount: {
     exclude: ["mapTime", "mapPct"],
     graphMods: (graph, highChartsObj) => {
-      highChartsObj.tooltip = formatters.defaultPoint;
+      highChartsObj.tooltip = { pointFormatter: formatters.defaultPoint };
       highChartsObj.yAxis.type = "Linear";
       highChartsObj.title.text = "Maps Run"
       highChartsObj.yAxis.title.text = "Maps Run"
@@ -948,7 +948,7 @@ var toggledGraphs = {
   mapPct: { // not used
     exclude: ["mapCount", "mapTime"],
     graphMods: (graph, highChartsObj) => {
-      highChartsObj.tooltip = formatters.defaultPoint;
+      highChartsObj.tooltip = { pointFormatter: formatters.defaultPoint };
       highChartsObj.yAxis.type = "Linear"
       highChartsObj.title.text = "% of Clear time spent Mapping"
       highChartsObj.yAxis.title.text = "% Clear Time"

--- a/Graphs.js
+++ b/Graphs.js
@@ -804,8 +804,10 @@ const getGameData = {
   //magmite: () => { return game.global.magmite },
   //magmamancers: () => { return game.jobs.Magmamancer.owned },
   fluffy: () => {
-    //sum of all previous evo costs + current exp
-    let exp = game.global.fluffyExp;
+    // cap exp at maximum for an evo, because Trimps doesn't do it and it causes horrible horrible bugs
+    let maxExp = Math.floor((1000 * Math.pow(5, Fluffy.getCurrentPrestige())) * ((Math.pow(4, 10) - 1) / (4 - 1)))
+    let exp = Math.min(game.global.fluffyExp, maxExp);
+    //sum of all previous evo costs + current exp, because Trimps doesn't store this
     for (var evo = 0; evo < Fluffy.getCurrentPrestige(); evo++) {
       exp += Math.floor((1000 * Math.pow(5, evo)) * ((Math.pow(4, 10) - 1) / (4 - 1)));;
     }

--- a/Graphs.js
+++ b/Graphs.js
@@ -125,6 +125,7 @@ function init() {
   toggleDiv.innerText = ""
   document.querySelector("#graphParent").appendChild(toggleDiv);
 
+
   // Handle Dark Graphs?  Old code
   MODULES.graphs.themeChanged = function () {
     if (game && game.options.menu.darkTheme.enabled != lastTheme) {
@@ -135,9 +136,9 @@ function init() {
         if ("graphSelection" == h.id) return void (2 != game.options.menu.darkTheme.enabled && (h.style.color = "black"));
       }
       toggleDarkGraphs();
-      var c = document.getElementsByTagName("input"),
-        d = document.getElementsByTagName("select"),
-        e = document.getElementById("graphFooterLine1").children;
+      var c = document.getElementsByTagName("input");
+      var d = document.getElementsByTagName("select");
+      var e = document.getElementById("graphFooterLine1").children;
       for (let h of c) f(h);
       for (let h of d) f(h);
       for (let h of e) f(h);
@@ -145,7 +146,9 @@ function init() {
     }
     game && (lastTheme = game.options.menu.darkTheme.enabled);
   }
+
   MODULES.graphs.themeChanged();
+  document.querySelector("#blackCB").checked = GRAPHSETTINGS.darkTheme
 }
 
 // Graph constructor 
@@ -400,6 +403,7 @@ function drawGraph() {
     checkbox.setAttribute("onclick", `GRAPHSETTINGS.toggles.${graph}.${toggle} = this.checked; drawGraph();`);
 
     label.innerText = toggle;
+    label.style.color = "#757575";
 
     container.appendChild(checkbox)
     container.appendChild(label)
@@ -506,23 +510,30 @@ function toggleClearButton() {
 
 function toggleDarkGraphs() {
   function removeDarkGraphs() {
-    var a = document.getElementById("dark-graph.css");
-    a && (document.head.removeChild(a), debug("Removing dark-graph.css file", "graphs"));
+    var darkcss = document.getElementById("dark-graph.css");
+    darkcss && (document.head.removeChild(darkcss), debug("Removing dark-graph.css file", "graphs"));
   }
   function addDarkGraphs() {
-    var a = document.getElementById("dark-graph.css");
-    if (!a) {
+    var darkcss = document.getElementById("dark-graph.css");
+    if (!darkcss) {
       var b = document.createElement("link");
       (b.rel = "stylesheet"), (b.type = "text/css"), (b.id = "dark-graph.css"), (b.href = basepath + "dark-graph.css"), document.head.appendChild(b), debug("Adding dark-graph.css file", "graphs");
     }
   }
   if (game) {
-    var c = document.getElementById("dark-graph.css"),
-      d = document.getElementById("blackCB").checked;
-    (!c && (0 == game.options.menu.darkTheme.enabled || 2 == game.options.menu.darkTheme.enabled)) || MODULES.graphs.useDarkAlways || d
-      ? addDarkGraphs()
-      : c && (1 == game.options.menu.darkTheme.enabled || 3 == game.options.menu.darkTheme.enabled || !d) && removeDarkGraphs();
+    var darkcss = document.getElementById("dark-graph.css")
+    var dark = document.getElementById("blackCB").checked;
+    saveSetting("darkTheme", dark)
+    if ((!darkcss && (0 == game.options.menu.darkTheme.enabled || 2 == game.options.menu.darkTheme.enabled)) || MODULES.graphs.useDarkAlways || dark) {
+      addDarkGraphs()
+    }
+    else {
+      if (darkcss && (1 == game.options.menu.darkTheme.enabled || 3 == game.options.menu.darkTheme.enabled || !dark)) {
+        removeDarkGraphs();
+      }
+    }
   }
+
 }
 // ####### end scary old code
 
@@ -563,7 +574,7 @@ function autoToggleGraph() {
   var a = document.getElementById("autoTrimpsTabBarMenu");
   a && "block" === a.style.display && (a.style.display = "none");
   var b = document.getElementById("graphParent");
-  "block" === b.style.display ? (b.style.display = "none") : ((b.style.display = "block")); // , displayGraph()
+  "block" === b.style.display ? (b.style.display = "none") : ((b.style.display = "block"));
 }
 
 // focus main game
@@ -801,7 +812,8 @@ var GRAPHSETTINGS = {
   u1graphSelection: null,
   u2graphSelection: null,
   rememberSelected: [],
-  toggles: {}
+  toggles: {},
+  darkTheme: true
 }
 var portalSaveData = {}
 

--- a/Graphs.js
+++ b/Graphs.js
@@ -613,20 +613,33 @@ function pushData() {
 
 // Hide graphs that have no collected data
 function showHideUnusedGraphs() {
+  let activeUniverses = [];
   for (const graph of graphList) {
-    let style = "none"
-    if (graph.graphType != "line") continue;
+    if (graph.graphType != "line") continue; // ignore column graphs (pure laziness, the only two always exist anyways)
     const universes = graph.universe ? [graph.universe] : [1, 2]
     for (const universe of universes) {
+      let style = "none"
       for (portal of Object.values(portalSaveData)) {
-        if (portal.perZoneData[graph.dataVar] && portal.universe == universe  // has collected data, in the right universe
+        if (portal.perZoneData[graph.dataVar] && portal.universe === universe  // has collected data, in the right universe
           && portal.perZoneData[graph.dataVar].some((z) => { return !(z === 0 || z === null) })) { // and there is nonzero data
           style = ""
+          if (!activeUniverses.includes(universe)) activeUniverses.push(universe);
           break;
         }
       }
+      // hide unused graphs
       document.querySelector(`#u${universe}graphSelection [value="${graph.selectorText}"]`).style.display = style;
     }
+  }
+  // hide universe selector if graphs are only in one universe
+  let universeSel = document.querySelector(`#universeSelection`);
+  if (activeUniverses.length === 1) {
+    universeSel.style.display = "none";
+    GRAPHSETTINGS.universeSelection = activeUniverses[0];
+    swapGraphUniverse()
+  }
+  else {
+    universeSel.style.display = "";
   }
 }
 

--- a/Graphs.js
+++ b/Graphs.js
@@ -443,13 +443,14 @@ function Portal() {
     this.initialScruffy = getGameData.scruffy();
     this.s3 = getGameData.s3();
   }
-  // create an object to collect only the relevant data per zone
-  this.perZoneData = Object.fromEntries(graphList.filter((graph) =>
+  // create an object to collect only the relevant data per zone, without fromEntries because old JS
+  this.perZoneData = {};
+  var perZoneItems = graphList.filter((graph) =>
     (graph.universe == this.universe || !graph.universe) // only save data relevant to the current universe
     && graph.conditional() && graph.dataVar) // and for relevant challenges, with datavars 
-    .map(graph => [graph.dataVar, []]) // create data structure
-    .concat([["currentTime", []]]) // always graph time
-  );
+    .map((graph) => graph.dataVar)
+    .concat(["currentTime"]); // always graph time
+  perZoneItems.forEach((name) => this.perZoneData[name] = []);
   // update per zone data and special totals
   this.update = function () {
     const world = getGameData.world();

--- a/Graphs.js
+++ b/Graphs.js
@@ -728,7 +728,7 @@ const graphList = [
     toggles: ["perHr", "perZone", "lifetime"]
   }],
   ["fluffy", 1, "Fluffy Exp", {
-    conditional: () => { return getGameData.u1hze() >= 300 && getGameData.fluffy() < 3415819248011889 }, // pre unlock, post E10L10
+    conditional: () => { return getGameData.u1hze() >= 300 && getGameData.fluffy() < 3413330078125000 }, // pre unlock, post E10L10
     customFunction: (portal, i) => { return diff("fluffy", portal.initialFluffy)(portal, i) },
     toggles: ["perHr", "perZone",]
   }],
@@ -838,7 +838,7 @@ const getGameData = {
     //sum of all previous evo costs + current exp
     let exp = game.global.fluffyExp;
     for (var evo = 0; evo < Fluffy.getCurrentPrestige(); evo++) {
-      exp += 111848 * 5 ** (evo + 5);
+      exp += Math.floor((1000 * Math.pow(5, evo)) * ((Math.pow(4, 10) - 1) / (4 - 1)));;
     }
     return exp
   },

--- a/Graphs.js
+++ b/Graphs.js
@@ -639,20 +639,17 @@ function escapeATWindows() {
   if ("none" != a.style.display) return void cancelTooltip();
   game.options.displayed && toggleSettingsMenu();
   var b = document.getElementById("autoSettings");
-  "block" === b.style.display && (b.style.display = "none");
+  if (b) "block" === b.style.display && (b.style.display = "none");
   var b = document.getElementById("autoTrimpsTabBarMenu");
-  "block" === b.style.display && (b.style.display = "none");
+  if (b) "block" === b.style.display && (b.style.display = "none");
   var c = document.getElementById("graphParent");
-  "block" === c.style.display && (c.style.display = "none");
+  if (c) "block" === c.style.display && (c.style.display = "none");
 }
 document.addEventListener(
   "keydown",
   function (a) {
     1 != game.options.menu.hotkeys.enabled || game.global.preMapsActive || game.global.lockTooltip
       || ctrlPressed || heirloomsShown || 27 != a.keyCode || escapeATWindows();
-    if (["1", "2", "3", "4", "5"].includes(a.key)) {
-      //a.stopPropagation() // does not work, whee
-    }
   },
   true
 );

--- a/Graphs.js
+++ b/Graphs.js
@@ -637,7 +637,6 @@ function autoToggleGraph() {
 function escapeATWindows() {
   var a = document.getElementById("tooltipDiv");
   if ("none" != a.style.display) return void cancelTooltip();
-  game.options.displayed && toggleSettingsMenu();
   var b = document.getElementById("autoSettings");
   if (b) "block" === b.style.display && (b.style.display = "none");
   var b = document.getElementById("autoTrimpsTabBarMenu");
@@ -645,6 +644,7 @@ function escapeATWindows() {
   var c = document.getElementById("graphParent");
   if (c) "block" === c.style.display && (c.style.display = "none");
 }
+
 document.addEventListener(
   "keydown",
   function (a) {

--- a/Graphs.js
+++ b/Graphs.js
@@ -544,6 +544,9 @@ function saveSelectedGraphs() {
   saveSetting();
 }
 function applyRememberedSelections() {
+  if (chart1.series.length < GRAPHSETTINGS.rememberSelected.length) {
+    GRAPHSETTINGS.rememberSelected.splice(chart1.series.length); // cleanup after portal deletion
+  }
   for (let i = 0; i < chart1.series.length; i++) {
     if (GRAPHSETTINGS.rememberSelected[i] === false) { chart1.series[i].hide(); }
   }

--- a/Graphs.js
+++ b/Graphs.js
@@ -477,9 +477,11 @@ function clearData(keepN, clrall = false) {
       }
     }
   } else {
+    let totalSaved = Object.keys(portalSaveData).length;
     for (const [portalID, portalData] of Object.entries(portalSaveData)) {
-      if (portalData.totalPortals < currentPortalNumber - keepN) {
+      if (totalSaved > keepN && portalData.totalPortals <= currentPortalNumber - keepN) {
         delete portalSaveData[portalID];
+        totalSaved--;
       }
     }
   }
@@ -489,13 +491,12 @@ function clearData(keepN, clrall = false) {
 
 function deleteSpecific() {
   let portalNum = Number(document.getElementById("deleteSpecificTextBox").value);
-  if (portalNum > 0)
-    if (0 > parseInt(portalNum)) clearData(Math.abs(portalNum));
-    else {
-      for (const [portalID, portalData] of Object.entries(portalSaveData)) {
-        if (portalData.totalPortals === portalNum) delete portalSaveData[portalID];
-      }
+  if (parseInt(portalNum) < 0) { clearData(Math.abs(portalNum)); }
+  else {
+    for (const [portalID, portalData] of Object.entries(portalSaveData)) {
+      if (portalData.totalPortals === portalNum) delete portalSaveData[portalID];
     }
+  }
   savePortalData(true)
   showHideUnusedGraphs();
 }
@@ -708,6 +709,10 @@ const graphList = [
     customFunction: (portal, i) => { return diff("essence", portal.initialDE)(portal, i) },
     toggles: ["perHr"]
   }],
+  ["lastWarp", 1, "Warpstations", {
+    graphTitle: "Warpstations built on previous Giga",
+    conditional: () => { return getGameData.u1hze() > 60 && ((game.global.totalHeliumEarned - game.global.heliumLeftover) < 10 ** 10) }, // Warp unlock, less than 10B He allocated
+  }],
   ["amals", 1, "Amalgamators"],
   ["wonders", 1, "Wonders", {
     conditional: () => { return getGameData.challengeActive() === "Experience" }
@@ -794,7 +799,7 @@ const getGameData = {
   zoneTime: () => { return new Date().getTime() - game.global.zoneStarted },
   mapbonus: () => { return game.global.mapBonus },
   empower: () => { return game.global.challengeActive == "Daily" && typeof game.global.dailyChallenge.empower !== "undefined" ? game.global.dailyChallenge.empower.stacks : 0 },
-  lastwarp: () => { return game.global.lastWarp },
+  lastWarp: () => { return game.global.lastWarp },
   essence: () => { return game.global.spentEssence + game.global.essence },
   heliumOwned: () => { return game.resources.helium.owned },
   magmite: () => { return game.global.magmite },

--- a/Graphs.js
+++ b/Graphs.js
@@ -317,6 +317,7 @@ function Graph(dataVar, universe, selectorText, additionalParams = {}) {
     this.graphData = [];
     var yAxis = 0;
     for (const column of activeColumns) {
+      // TODO set colors based on dataVar to make Zek happy
       let cleanData = []
       for (const portal of Object.values(portalSaveData)) {
         if (portal.universe != GRAPHSETTINGS.universeSelection) continue;
@@ -602,10 +603,11 @@ function autoToggleGraph() {
   var graphParent = document.getElementById("graphParent");
   if ("block" === graphParent.style.display) {
     graphParent.style.display = "none";
+    trimpStatsDisplayed = false // HACKS disable hotkeys without touching Trimps settings
   }
   else {
     graphParent.style.display = "block";
-    document.getElementById("deleteSpecificTextBox").focus()
+    trimpStatsDisplayed = true // HACKS disable hotkeys without touching Trimps settings
   }
 }
 

--- a/Graphs.js
+++ b/Graphs.js
@@ -503,7 +503,7 @@ function Portal() {
       }
       if (name === "timeOnMap") {
         let timeOnMap = getGameData.timeOnMap();
-        if (fromMap) { data[world] = data[world] + timeOnMap || timeOnMap; }// additive per map within a zone
+        if (fromMap) { data[world] = data[world] + timeOnMap || timeOnMap; } // additive per map within a zone
         continue;
       }
       if (name === "mapCount") {
@@ -775,15 +775,18 @@ const graphList = [
   ["essence", 1, "Dark Essence", {
     conditional: () => { return getGameData.essence() < 5.826e+39 },
     customFunction: (portal, i) => { return diff("essence", portal.initialDE)(portal, i) },
-    toggles: ["perHr", "perZone",]
+    toggles: ["perHr", "perZone",],
+    xminFloor: 181,
   }],
   ["lastWarp", 1, "Warpstations", {
     graphTitle: "Warpstations built on previous Giga",
     conditional: () => { return getGameData.u1hze() > 60 && ((game.global.totalHeliumEarned - game.global.heliumLeftover) < 10 ** 10) }, // Warp unlock, less than 10B He allocated
+    xminFloor: 60,
   }],
   ["amals", 1, "Amalgamators"],
   ["wonders", 1, "Wonders", {
-    conditional: () => { return getGameData.challengeActive() === "Experience" }
+    conditional: () => { return getGameData.challengeActive() === "Experience" },
+    xminFloor: 300,
   }],
 
   // U2 Graphs
@@ -797,10 +800,12 @@ const graphList = [
   ["mutatedSeeds", 2, "Mutated Seeds", {
     conditional: () => { return getGameData.u2hze() > 200 },
     customFunction: (portal, i) => { return diff("mutatedSeeds", portal.initialMutes)(portal, i) },
-    toggles: ["perHr", "perZone"]
+    toggles: ["perHr", "perZone"],
+    xminFloor: 200,
   }],
   ["worshippers", 2, "Worshippers", {
-    conditional: () => { return getGameData.u2hze() >= 50 }
+    conditional: () => { return getGameData.u2hze() >= 50 },
+    xminFloor: 50,
   }],
   ["smithies", 2, "Smithies"],
   ["bonfires", 2, "Bonfires", {

--- a/Graphs.js
+++ b/Graphs.js
@@ -1,1179 +1,838 @@
-//yes
-var allSaveData = [],
-    graphData = [],
-    tmpGraphData = JSON.parse(localStorage.getItem("allSaveData"));
-null !== tmpGraphData && (console.log("Graphs: Found allSaveData (portal runs data). Yay!"), (allSaveData = tmpGraphData)), (MODULES.graphs = {}), (MODULES.graphs.useDarkAlways = !1);
-var head = document.getElementsByTagName("head")[0],
-    chartscript = document.createElement("script");
-(chartscript.type = "text/javascript"), (chartscript.src = "https://Zorn192.github.io/AutoTrimps/highcharts.js"), head.appendChild(chartscript);
-var newItem = document.createElement("TD");
-newItem.appendChild(document.createTextNode("Graphs")), newItem.setAttribute("class", "btn btn-default"), newItem.setAttribute("onclick", "autoToggleGraph(); drawGraph(undefined, undefined, true);");
-var settingbarRow = document.getElementById("settingsTable").firstElementChild.firstElementChild;
-settingbarRow.insertBefore(newItem, settingbarRow.childNodes[10]),
-    (document.getElementById("settingsRow").innerHTML += '<div id="graphParent" style="display: none; height: 600px; overflow: auto;"><div id="graph" style="margin-bottom: 10px;margin-top: 5px; height: 530px;"></div>'),
-    (document.getElementById("graphParent").innerHTML +=
-        '<div id="graphFooter" style="height: 50px;font-size: 1em;"><div id="graphFooterLine1" style="display: -webkit-flex;flex: 0.75;flex-direction: row; height:30px;"></div><div id="graphFooterLine2"></div></div>');
-var $universeFooter = document.getElementById("graphFooterLine1"),
-    universeList = [
-        "Universe 1",
-        "Universe 2",
-    ],
-    $universeSel = document.createElement("select");
-for (var item in (($universeSel.id = "universeSelection"), $universeSel.setAttribute("style", ""), $universeSel.setAttribute("onchange", "drawGraph()"), universeList)) {
-    var $opt = document.createElement("option");
-    ($opt.value = universeList[item]), ($opt.text = universeList[item]), $universeSel.appendChild($opt);
-}
-var $u1Graph = document.getElementById("graphFooterLine1"),
-    u1graphList = [
-        "Helium - He/Hr",
-        "Helium - Total",
-        "HeHr % / LifetimeHe",
-        "He % / LifetimeHe",
-        "Clear Time",
-        "Cumulative Clear Time",
-        "Map Bonus",
-        "Void Maps",
-        "Void Map History",
-        "Coordinations",
-        "Nullifium Gained",
-        "OverkillCells",
-        "Fluffy XP",
-        "Fluffy XP PerHour",
-        "Amalgamators",
-	"Wonders",
-        "Empower"
-    ],
-    $u1graphSel = document.createElement("select");
-for (var item in (($u1graphSel.id = "u1graphSelection"), $u1graphSel.setAttribute("style", ""), $u1graphSel.setAttribute("onchange", "drawGraph()"), u1graphList)) {
-    var $opt = document.createElement("option");
-    ($opt.value = u1graphList[item]), ($opt.text = u1graphList[item]), $u1graphSel.appendChild($opt);
-} 
-var $u2Graph = document.getElementById("graphFooterLine1"),
-    u2graphList = [
-        "Radon - Rn/Hr",
-        "Radon - Rn/Hr Normalized",
-        "Radon - Total",
-        "RnHr % / LifetimeRn",
-        "Rn % / LifetimeRn",
-        "Clear Time",
-        "Cumulative Clear Time",
-        "Map Bonus",
-        "Void Maps",
-        "Void Map History",
-        "Coordinations",
-        "OverkillCells",
-        "Smithies",
-        "Scruffy XP",
-        "Scruffy XP PerHour",
-	"Worshippers",
-        "Bonfires",
-        "Embers",
-        "Cruffys",
-        "Empower"
-    ],
-    $u2graphSel = document.createElement("select");
-for (var item in (($u2graphSel.id = "u2graphSelection"), $u2graphSel.setAttribute("style", ""), $u2graphSel.setAttribute("onchange", "drawGraph()"), u2graphList)) {
-    var $opt = document.createElement("option");
-    ($opt.value = u2graphList[item]), ($opt.text = u2graphList[item]), $u2graphSel.appendChild($opt);
-}
-$universeFooter.appendChild($universeSel),
-$universeFooter.appendChild($u1graphSel),
-$universeFooter.appendChild($u2graphSel),
-($universeFooter.innerHTML +=
-    '<div><button onclick="drawGraph(true,false)" style="margin-left:0.5em; width:2em;">\u2191</button></div><div><button onclick="drawGraph(false,true)" style="margin-left:0.5em; width:2em;">\u2193</button></div><div><button onclick="drawGraph()" style="margin-left:0.5em;">Refresh</button></div><div style="flex:0 100 5%;"></div><div><input type="checkbox" id="clrChkbox" onclick="toggleClearButton();"></div><div style="margin-left: 0.5vw;"><button id="clrAllDataBtn" onclick="clearData(null,true); drawGraph();" class="btn" disabled="" style="flex:auto; padding: 2px 6px;border: 1px solid white;">Clear All Previous Data</button></div><div style="flex:0 100 5%;"></div><div style="flex:0 2 3.5vw;"><input style="width:100%;min-width: 40px;" id="deleteSpecificTextBox"></div><div style="flex:auto; margin-left: 0.5vw;"><button onclick="deleteSpecific(); drawGraph();">Delete Specific Portal</button></div><div style="flex:0 100 5%;"></div><div style="flex:auto;"><button  onclick="GraphsImportExportTooltip(\'ExportGraphs\', null, \'update\')" onmouseover=\'tooltip("Tips", "customText", event, "Export Graph Database will make a backup of all the graph data to a text string.<b>DISCLAIMER:</b> Takes quite a long time to generate.")\' onmouseout=\'tooltip("hide")\'>Export your Graph Database</button></div><div style="float:right; margin-right: 0.5vw;"><button onclick="addGraphNoteLabel()">Add Note/Label</button></div><div style="float:right; margin-right: 0.5vw;"><button onclick="toggleSpecificGraphs()">Invert Selection</button></div><div style="float:right; margin-right: 1vw;"><button onclick="toggleAllGraphs()">All Off/On</button></div>'),
-(document.getElementById("graphFooterLine2").innerHTML +=
-    '<span style="float: left;" onmouseover=\'tooltip("Tips", "customText", event, "You can zoom by dragging a box around an area. You can turn portals off by clicking them on the legend. Quickly view the last portal by clicking it off, then Invert Selection. Or by clicking All Off, then clicking the portal on. To delete a portal, Type its portal number in the box and press Delete Specific. Using negative numbers in the Delete Specific box will KEEP that many portals (starting counting backwards from the current one), ie: if you have Portals 1000-1015, typing -10 will keep 1005-1015. There is a browser data storage limitation of 10MB, so do not exceed 20 portals-worth of data.")\' onmouseout=\'tooltip("hide")\'>Tips: Hover for usage tips.</span><input style="height: 20px; float: right; margin-right: 0.5vw;" type="checkbox" id="rememberCB"><span style="float: right; margin-right: 0.5vw;">Try to Remember Which Portals are Selected when switching between Graphs:</span><input onclick="toggleDarkGraphs()" style="height: 20px; float: right; margin-right: 0.5vw;" type="checkbox" id="blackCB"><span style="float: right; margin-right: 0.5vw;">Black Graphs:</span>');
-function toggleClearButton() {
-    document.getElementById("clrAllDataBtn").disabled = !document.getElementById("clrChkbox").checked;
-}
-function addDarkGraphs() {
-    var a = document.getElementById("dark-graph.css");
-    if (!a) {
-        var b = document.createElement("link");
-        (b.rel = "stylesheet"), (b.type = "text/css"), (b.id = "dark-graph.css"), (b.href = basepath + "dark-graph.css"), document.head.appendChild(b), debug("Adding dark-graph.css file", "graphs");
+function safeLocalStorage(name, data) {
+  try {
+    if (name === "portalDataCurrent") {
+      // save at most every 450ms. Stringify is too expensive to run at max speed in timewarp, but still save every zone in liq otherwise
+      if ((new Date() - lastSave) / 450 < 1) return
+      else lastSave = new Date();
     }
-}
-function removeDarkGraphs() {
-    var a = document.getElementById("dark-graph.css");
-    a && (document.head.removeChild(a), debug("Removing dark-graph.css file", "graphs"));
-}
-function toggleDarkGraphs() {
-    if (game) {
-        var c = document.getElementById("dark-graph.css"),
-            d = document.getElementById("blackCB").checked;
-        (!c && (0 == game.options.menu.darkTheme.enabled || 2 == game.options.menu.darkTheme.enabled)) || MODULES.graphs.useDarkAlways || d
-            ? addDarkGraphs()
-            : c && (1 == game.options.menu.darkTheme.enabled || 3 == game.options.menu.darkTheme.enabled || !d) && removeDarkGraphs();
+    if (typeof data != "string") data = JSON.stringify(data);
+    localStorage.setItem(name, data);
+  } catch (e) {
+    if (e.code == 22 || e.code == 1014) { // 
+      // Storage full, delete oldest portal from history, and try again
+      delete portalSaveData[Object.keys(portalSaveData)[0]];
+      savePortalData(true);
+      safeLocalStorage(name, data)
+      console.debug("AT Graphs Error: LocalStorage is full. Automatically deleting a graph to clear up space.", e.code, e);
     }
+  }
 }
-var lastTheme = -1;
-(MODULES.graphs.themeChanged = function () {
+
+// Save Portal Data to history, or current only
+function savePortalData(saveAll = true) {
+  var currentPortal = getportalID();
+  if (saveAll) {
+    safeLocalStorage("portalDataHistory", LZString.compressToBase64(JSON.stringify(portalSaveData)))
+  }
+  else {
+    let portalObj = {}
+    portalObj[currentPortal] = portalSaveData[currentPortal];
+    safeLocalStorage("portalDataCurrent", portalObj)
+  }
+}
+
+// Save settings, with or without updating a key
+function saveSetting(key, value) {
+  if (key !== null && value !== null) GRAPHSETTINGS[key] = value;
+  safeLocalStorage("GRAPHSETTINGS", GRAPHSETTINGS);
+}
+
+// Create all of the UI elements and load in scripts needed
+// TODO reduce screaming
+function init() {
+  var head = document.getElementsByTagName("head")[0]
+
+  var chartscript = document.createElement("script");
+  chartscript.type = "text/javascript";
+  chartscript.src = "https://code.highcharts.com/highcharts.js";
+  head.appendChild(chartscript);
+
+  var graphsButton = document.createElement("TD");
+  graphsButton.appendChild(document.createTextNode("Graphs"))
+  graphsButton.setAttribute("class", "btn btn-default")
+  graphsButton.setAttribute("onclick", "autoToggleGraph(); drawGraph(); swapGraphUniverse();");
+
+  var settingbarRow = document.getElementById("settingsTable").firstElementChild.firstElementChild;
+  settingbarRow.insertBefore(graphsButton, settingbarRow.childNodes[10])
+
+  document.getElementById("settingsRow").innerHTML += `
+        <div id="graphParent" style="display: none; height: 600px; overflow: auto; position: relative;">
+            <div id="graph" style="margin-bottom: 10px;margin-top: 5px; height: 530px;"></div>
+            <div id="graphFooter" style="height: 50px;font-size: 1em;">
+                <div id="graphFooterLine1" style="display: -webkit-flex;flex: 0.75;flex-direction: row; height:30px;"></div>
+                <div id="graphFooterLine2"></div>
+            </div>
+        </div>
+        `;
+
+  function createSelector(id, sourceList, textMod = "", onchangeMod = "") {
+    let selector = document.createElement("select");
+    selector.id = id;
+    selector.setAttribute("style", "");
+    selector.setAttribute("onchange", "saveSetting(this.id, this.value); drawGraph();" + onchangeMod);
+    for (var item of sourceList) {
+      let opt = document.createElement("option");
+      opt.value = item;
+      opt.text = textMod + item;
+      selector.appendChild(opt);
+    }
+    selector.value = GRAPHSETTINGS[selector.id]
+    return selector;
+  }
+
+  // Create Universe and Graph selectors
+  var universeFooter = document.getElementById("graphFooterLine1");
+  [
+    ["universeSelection", [1, 2], "Universe ", " swapGraphUniverse();"],
+    ["u1graphSelection", graphList.filter((g) => g.universe == 1 || !g.universe).map((g) => g.selectorText)],
+    ["u2graphSelection", graphList.filter((g) => g.universe == 2 || !g.universe).map((g) => g.selectorText)]
+  ].forEach((opts) => universeFooter.appendChild(createSelector(...opts)))
+
+  universeFooter.innerHTML += `
+    <div><button onclick="drawGraph()" style="margin-left:0.5em;">Refresh</button></div>
+    <div style="flex:0 100 5%;"></div>
+    <div><input type="checkbox" id="clrChkbox" onclick="toggleClearButton();"></div>
+    <div style="margin-left: 0.5vw;">
+      <button id="clrAllDataBtn" onclick="clearData(null,true); drawGraph();" class="btn" disabled="" style="flex:auto; padding: 2px 6px;border: 1px solid white;">
+        Clear All Previous Data</button></div>
+    <div style="flex:0 100 5%;"></div>
+    <div style="flex:0 2 3.5vw;"><input style="width:100%;min-width: 40px;" id="deleteSpecificTextBox"></div>
+    <div style="flex:auto; margin-left: 0.5vw;"><button onclick="deleteSpecific(); drawGraph();">Delete Specific Portal</button></div>
+    <div style="float:right; margin-right: 0.5vw;"><button onclick="toggleSpecificGraphs()">Invert Selection</button></div>
+    <div style="float:right; margin-right: 1vw;"><button onclick="toggleAllGraphs()">All Off/On</button></div>`
+
+  // AAAAAAAAAAAAAAAAAAAAAAAAAAAA (Setting the inner HTML of the parent element resets the value of these? what the fuck)
+  document.querySelector("#universeSelection").value = GRAPHSETTINGS.universeSelection
+  document.querySelector("#u1graphSelection").value = GRAPHSETTINGS.u1graphSelection
+  document.querySelector("#u2graphSelection").value = GRAPHSETTINGS.u2graphSelection
+
+  let tipsText = `
+    You can zoom by dragging a box around an area. You can turn portals off by clicking them on the legend. 
+    Quickly view the last portal by clicking it off, then Invert Selection. Or by clicking All Off, then clicking the portal on. 
+    To delete a portal, Type its portal number in the box and press Delete Specific. 
+    Using negative numbers in the Delete Specific box will KEEP that many portals (starting counting backwards from the current one), 
+    ie: if you have Portals 1000-1015, typing -10 will keep 1005-1015."
+    `
+  document.getElementById("graphFooterLine2").innerHTML += `
+    <span style="float: left;" onmouseover=\'tooltip("Tips", "customText", event, "${tipsText}")\' onmouseout=\'tooltip("hide")\'>Tips: Hover for usage tips.</span>
+    <input onclick="toggleDarkGraphs()" style="height: 20px; float: right; margin-right: 0.5vw;" type="checkbox" id="blackCB">
+    <span style="float: right; margin-right: 0.5vw;">Black Graphs:</span>`;
+
+  // Add a header with negative float hanging down on the top of the graph, for toggle buttons
+  var toggleDiv = document.createElement("div");
+  toggleDiv.id = "toggleDiv";
+  toggleDiv.setAttribute("style", "position: absolute; top: 1rem; left: 3rem; z-index: 1;")
+  toggleDiv.innerText = ""
+  document.querySelector("#graphParent").appendChild(toggleDiv);
+
+  // Handle Dark Graphs?  Old code
+  MODULES.graphs.themeChanged = function () {
     if (game && game.options.menu.darkTheme.enabled != lastTheme) {
-        function f(h) {
-            h.style.color = 2 == game.options.menu.darkTheme.enabled ? "" : "black";
-        }
-        function g(h) {
-            if ("graphSelection" == h.id) return void (2 != game.options.menu.darkTheme.enabled && (h.style.color = "black"));
-        }
-        toggleDarkGraphs();
-        var c = document.getElementsByTagName("input"),
-            d = document.getElementsByTagName("select"),
-            e = document.getElementById("graphFooterLine1").children;
-        for (let h of c) f(h);
-        for (let h of d) f(h);
-        for (let h of e) f(h);
-        for (let h of e) g(h);
+      function f(h) {
+        h.style.color = 2 == game.options.menu.darkTheme.enabled ? "" : "black";
+      }
+      function g(h) {
+        if ("graphSelection" == h.id) return void (2 != game.options.menu.darkTheme.enabled && (h.style.color = "black"));
+      }
+      toggleDarkGraphs();
+      var c = document.getElementsByTagName("input"),
+        d = document.getElementsByTagName("select"),
+        e = document.getElementById("graphFooterLine1").children;
+      for (let h of c) f(h);
+      for (let h of d) f(h);
+      for (let h of e) f(h);
+      for (let h of e) g(h);
     }
     game && (lastTheme = game.options.menu.darkTheme.enabled);
-}),
-    MODULES.graphs.themeChanged();
-function GraphsImportExportTooltip(a) {
-    if (!game.global.lockTooltip) {
-        var d = document.getElementById("tooltipDiv");
-        swapClass("tooltipExtra", "tooltipExtraNone", d);
-        var f,
-            e = null,
-            g = "";
-        "ExportGraphs" == a &&
-            ((f =
-                "This is your GRAPH DATABASE save string. There are many like it but this one is yours. Save this save somewhere safe so you can save time next time. <br/><br/><textarea id='exportArea' style='width: 100%' rows='5'>" +
-                JSON.stringify(allSaveData) +
-                "</textarea>"),
-            (g = "<div class='maxCenter'><div id='confirmTooltipBtn' class='btn btn-info' onclick='cancelTooltip()'>Got it</div>"),
-            document.queryCommandSupported("copy")
-                ? ((g += "<div id='clipBoardBtn' class='btn btn-success'>Copy to Clipboard</div>"),
-                  (e = function () {
-                      document.getElementById("exportArea").select(),
-                          document.getElementById("clipBoardBtn").addEventListener("click", function () {
-                              document.getElementById("exportArea").select();
-                              try {
-                                  document.execCommand("copy");
-                              } catch (i) {
-                                  document.getElementById("clipBoardBtn").innerHTML = "Error, not copied";
-                              }
-                          });
-                  }))
-                : (e = function () {
-                      document.getElementById("exportArea").select();
-                  }),
-            (g += "</div>")),
-            "ImportGraphs" == a &&
-                ((f = "Replaces your GRAPH DATABASE with this save string! It'll be fine, I promise.<br/><br/><textarea id='importBox' style='width: 100%' rows='5'></textarea>"),
-                (g = "<div class='maxCenter'><div id='confirmTooltipBtn' class='btn btn-info' onclick='cancelTooltip(); loadGraphs();'>Import</div><div class='btn btn-info' onclick='cancelTooltip()'>Cancel</div></div>"),
-                (e = function () {
-                    document.getElementById("importBox").focus();
-                })),
-            "AppendGraphs" == a &&
-                ((f = "Appends to your GRAPH DATABASE with this save string (combines them)! It'll be fine, I hope.<br/><br/><textarea id='importBox' style='width: 100%' rows='5'></textarea>"),
-                (g = "<div class='maxCenter'><div id='confirmTooltipBtn' class='btn btn-info' onclick='cancelTooltip(); appendGraphs();'>Import</div><div class='btn btn-info' onclick='cancelTooltip()'>Cancel</div></div>"),
-                (e = function () {
-                    document.getElementById("importBox").focus();
-                })),
-            (game.global.lockTooltip = !0),
-            (d.style.left = "33.75%"),
-            (d.style.top = "25%"),
-            (document.getElementById("tipTitle").innerHTML = a),
-            (document.getElementById("tipText").innerHTML = f),
-            (document.getElementById("tipCost").innerHTML = g),
-            (d.style.display = "block"),
-            null != e && e();
+  }
+  MODULES.graphs.themeChanged();
+}
+
+// Graph constructor 
+function Graph(dataVar, universe, selectorText, additionalParams = {}) {
+  // graphTitle, customFunction, useAccumulator, xTitle, yTitle, formatter, xminFloor, yminFloor, yType
+  this.dataVar = dataVar
+  this.universe = universe; // false, 1, 2
+  this.selectorText = selectorText ? selectorText : dataVar;
+  this.graphTitle = this.selectorText;
+  this.graphType = "line"
+  this.customFunction;
+  this.useAccumulator;
+  this.xTitle = "Zone";
+  this.yTitle = this.selectorText;
+  this.formatter;
+  this.xminFloor = 1;
+  this.yminFloor;
+  this.yType = "Linear";
+  this.graphData = [];
+  this.typeCheck = "number"
+  this.conditional = () => { return true };
+  for (const [key, value] of Object.entries(additionalParams)) {
+    this[key] = value;
+  }
+  this.baseGraphTitle = this.graphTitle;
+
+  // create an object to pass to Highcharts.Chart
+  this.createHighChartsObj = function () {
+    // TODO BUGS Max values sometimes clip
+    return {
+      chart: {
+        renderTo: "graph",
+        zoomType: "xy",
+        resetZoomButton: {
+          position: {
+            align: "right",
+            verticalAlign: "top",
+            x: -20,
+            y: 15,
+          },
+          relativeTo: "chart",
+        },
+      },
+      colors: ["#e60049", "#0bb4ff", "#50e991", "#e6d800", "#9b19f5", "#ffa300", "#dc0ab4", "#b3d4ff", "#00bfa0"],
+      title: {
+        text: this.graphTitle,
+        x: -20,
+      },
+      plotOptions: {
+        series: {
+          lineWidth: 1,
+          animation: false,
+          marker: {
+            enabled: false,
+          },
+        },
+      },
+      xAxis: {
+        floor: this.xminFloor,
+        title: {
+          text: this.xTitle,
+        },
+      },
+      yAxis: {
+        floor: this.yminFloor,
+        title: {
+          text: this.yTitle,
+        },
+        plotLines: [
+          {
+            value: 0,
+            width: 1,
+            color: "#808080",
+          },
+        ],
+        type: this.yType,
+        labels: {
+          formatter: function () {
+            // These are Trimps format functions for durations(modified) and numbers, respectively
+            if (this.dateTimeLabelFormat) return formatDuration(this.value / 1000)
+            else return prettify(this.value);
+          }
+        }
+      },
+      tooltip: {
+        pointFormatter: this.formatter,
+      },
+      legend: {
+        layout: "vertical",
+        align: "right",
+        verticalAlign: "middle",
+        borderWidth: 0,
+      },
+      series: this.graphData,
+      additionalParams: {},
     }
+  }
+  // Main Graphing function
+  this.updateGraph = function () {
+    if (this.graphType == "line") this.lineGraph();
+    if (this.graphType == "column") this.columnGraph();
+    this.formatter = this.formatter
+      || function () {
+        var ser = this.series; // 'this' being the highcharts object that uses formatter()
+        return '<span style="color:' + ser.color + '" >●</span> ' + ser.name + ": <b>" + prettify(this.y) + "</b><br>";
+      };
+    saveSelectedGraphs();
+    chart1 = new Highcharts.Chart(this.createHighChartsObj());
+    applyRememberedSelections();
+  }
+  // prepares data series for Highcharts, and optionally transforms it with toggled options, customFunction and/or useAccumulator
+  this.lineGraph = function () {
+    var item = this.dataVar;
+    this.graphData = [];
+    this.graphTitle = this.baseGraphTitle;
+    var maxS3 = Math.max(...Object.values(portalSaveData).map((portal) => portal.s3).filter((s3) => s3));
+    if (this.toggles) {
+      // create save space for the toggles if they don't exist
+      if (GRAPHSETTINGS.toggles[this.selectorText] === undefined) { GRAPHSETTINGS.toggles[this.selectorText] = {} }
+      this.toggles.forEach((toggle) => {
+        if (GRAPHSETTINGS.toggles[this.selectorText][toggle] === undefined) { GRAPHSETTINGS.toggles[this.selectorText][toggle] = false }
+      })
+      // change the graph title per toggle
+      if (GRAPHSETTINGS.toggles[this.selectorText].perHr) { this.graphTitle += " / Hour" }
+      if (GRAPHSETTINGS.toggles[this.selectorText].lifetime) { this.graphTitle += " % of Lifetime Total" }
+      if (GRAPHSETTINGS.toggles[this.selectorText].s3normalized) { this.graphTitle += `, Normalized to z${maxS3} S3` }
+    }
+    // parse data per portal
+    for (const portal of Object.values(portalSaveData)) {
+      if (!(item in portal.perZoneData)) continue; // ignore blank
+      if (portal.universe != GRAPHSETTINGS.universeSelection) continue; // ignore inactive universe
+      let cleanData = [];
+      // parse the requested datavar
+      for (const index in portal.perZoneData[item]) {
+        let x = portal.perZoneData[item][index];
+        let time = portal.perZoneData.currentTime[index];
+        if (typeof this.customFunction === "function") {
+          x = this.customFunction(portal, index);
+          if (x < 0) x = null;
+        }
+        // TOGGLES
+        if (this.toggles) {
+          // Apply the toggled functions to the data
+          for (const [toggle, bool] of Object.entries(GRAPHSETTINGS.toggles[this.selectorText])) {
+            if (!bool) continue;
+            switch (toggle) {
+              case "perHr": {
+                x = x / ((time - portal.portalTime) / 3600000)
+                break;
+              }
+              case "lifetime": {
+                let initial;
+                if (item == "heliumOwned") initial = portal.totalHelium;
+                if (item == "radonOwned") initial = portal.totalRadon;
+                if (!initial) {
+                  debug("Attempted to calc lifetime percent of an unknown type:" + item);
+                  continue;
+                }
+                x = x / initial
+                break
+              }
+              case "s3normalized": {
+                x = x / 1.03 ** portal.s3 * 1.03 ** maxS3
+                break;
+              }
+            }
+          }
+        }
+
+        if (this.useAccumulator) x += cleanData.length === 0 ? 0 : cleanData.at(-1); // never used, leaving it in just in case
+        if (this.typeCheck && typeof x != this.typeCheck) x = null;
+        cleanData.push([index, x])
+      }
+      this.graphData.push({
+        name: `Portal ${portal.totalPortals}: ${portal.challenge}`,
+        data: cleanData,
+      })
+    }
+  }
+  // prepares column data series from per-portal data
+  this.columnGraph = function () {
+    var item = this.portalVar;
+    this.xTitle = "Portal"
+    this.graphData = [];
+    let cleanData = []
+    // future use: test for datavar in portal, or in perZoneData, if you ever want to make column graphs based on max(perZoneData)
+    for (const portal of Object.values(portalSaveData)) {
+      if (portal.universe == GRAPHSETTINGS.universeSelection) {
+        cleanData.push([portal.totalPortals, portal[item]])
+      }
+    }
+    this.graphData.push({
+      name: this.yTitle,
+      data: cleanData,
+      type: "column",
+    });
+  }
 }
-function loadGraphs() {
-    var a = document.getElementById("importBox").value.replace(/(\r\n|\n|\r|\s)/gm, ""),
-        b = JSON.parse(a);
-    null == b || ((allSaveData = b), drawGraph());
+
+// returns _d _h _m _s or _._s
+function formatDuration(timeSince) {
+  let timeObj = {
+    d: Math.floor(timeSince / 86400),
+    h: Math.floor(timeSince / 3600) % 24,
+    m: Math.floor(timeSince / 60) % 60,
+    s: Math.floor(timeSince % 60),
+  }
+  let milliseconds = Math.floor(timeSince % 1 * 10)
+  let timeString = "";
+  let unitsUsed = 0
+  for (const [unit, value] of Object.entries(timeObj)) {
+    if (value === 0 && timeString === "") continue;
+    unitsUsed++;
+    if (value) timeString += value.toString() + unit + " ";
+  }
+  if (unitsUsed <= 1) {
+    timeString = [timeObj.s.toString().padStart(1, "0"), milliseconds.toString(), "s"].join(".");
+  }
+  return timeString
 }
-function appendGraphs() {
-    drawGraph();
+
+// Show/hide the universe-specific graph selectors
+function swapGraphUniverse() {
+  let universe = GRAPHSETTINGS.universeSelection;
+  let active = `u${universe}`
+  let inactive = `u${universe == 1 ? 2 : 1}`
+  document.getElementById(`${active}graphSelection`).style.display = '';
+  document.getElementById(`${inactive}graphSelection`).style.display = 'none';
 }
-var rememberSelectedVisible = [];
+
+// Draws the graph currently selected by the user
+function drawGraph() {
+  function lookupGraph(selectorText) {
+    for (const graph of graphList) {
+      if (graph.selectorText === selectorText) return graph;
+    }
+  }
+  // TOGGLES
+  function makeCheckbox(graph, toggle) {
+    // create checkbox element labeled with the toggle
+    var container = document.createElement("span")
+    var checkbox = document.createElement("input");
+    var label = document.createElement("span");
+
+    container.style.padding = "0rem .5rem";
+
+    checkbox.type = "checkbox";
+    checkbox.id = toggle;
+    // initialize the checkbox to saved value
+    checkbox.checked = GRAPHSETTINGS.toggles[graph][toggle];
+    // set saved value on change, and update the graph
+    checkbox.setAttribute("onclick", `GRAPHSETTINGS.toggles.${graph}.${toggle} = this.checked; drawGraph();`);
+
+    label.innerText = toggle;
+
+    container.appendChild(checkbox)
+    container.appendChild(label)
+    return container;
+  }
+  pushData(); // update current zone data on request
+  let universe = GRAPHSETTINGS.universeSelection;
+  let selectedGraph = document.getElementById(`u${universe}graphSelection`);
+  if (selectedGraph.value) {
+    // draw the graph
+    let graph = lookupGraph(selectedGraph.value);
+    graph.updateGraph();
+    // create toggle elements
+    toggleDiv = document.querySelector("#toggleDiv")
+    toggleDiv.innerHTML = "";
+    if (graph.toggles) {
+      for (const toggle of graph.toggles) {
+        toggleDiv.appendChild(makeCheckbox(graph.selectorText, toggle))
+      }
+    }
+  }
+  showHideUnusedGraphs();
+}
+
+// Stores and updates data for an individual portal
+function Portal() {
+  this.universe = getGameData.universe();
+  this.totalPortals = getTotalPortals();
+  this.portalTime = getGameData.portalTime();
+  this.challenge = getGameData.challengeActive() === 'Daily'
+    ? getCurrentChallengePane().split('.')[0].substr(13).slice(0, 16) // names dailies by their start date, only moderately cursed
+    : getGameData.challengeActive();
+  this.totalNullifium = getGameData.nullifium();
+  this.totalVoidMaps = getGameData.totalVoids();
+  if (this.universe === 1) {
+    this.totalHelium = game.global.totalHeliumEarned;
+    this.initialFluffy = getGameData.fluffy();
+  }
+  if (this.universe === 2) {
+    this.totalRadon = game.global.totalRadonEarned;
+    this.initialScruffy = getGameData.scruffy();
+    this.s3 = getGameData.s3();
+  }
+  // create an object to collect only the relevant data per zone
+  this.perZoneData = Object.fromEntries(graphList.filter((graph) =>
+    (graph.universe == this.universe || !graph.universe) // only save data relevant to the current universe
+    && graph.conditional() && graph.dataVar) // and for relevant challenges, with datavars 
+    .map(graph => [graph.dataVar, []]) // create data structure
+    .concat([["currentTime", []]]) // always graph time
+  );
+  // update per zone data and special totals
+  this.update = function () {
+    const world = getGameData.world();
+    // TODO Nu is a rather fragile stat, assumes recycling everything on portal. Max throughout the run makes it slightly less crappy.
+    // It would be better to store an initial value, and compare to final value + recycle value
+    this.totalNullifium = Math.max(this.totalNullifium, getGameData.nullifium());
+    this.totalVoidMaps = getGameData.totalVoids();
+    for (const [name, data] of Object.entries(this.perZoneData)) {
+      data[world] = getGameData[name]();
+      if (world + 1 < data.length) { // FENCEPOSTING
+        data.splice(world + 1) // trim 'future' zones on reload
+      }
+    }
+  }
+}
+
+function clearData(keepN, clrall = false) {
+  let currentPortalNumber = getTotalPortals();
+  if (clrall) {
+    for (const [portalID, portalData] of Object.entries(portalSaveData)) {
+      if (portalData.totalPortals != currentPortalNumber) {
+        delete portalSaveData[portalID];
+      }
+    }
+  } else {
+    for (const [portalID, portalData] of Object.entries(portalSaveData)) {
+      if (portalData.totalPortals < currentPortalNumber - keepN) {
+        delete portalSaveData[portalID];
+      }
+    }
+  }
+  savePortalData(true)
+  showHideUnusedGraphs();
+}
+
+function deleteSpecific() {
+  let portalNum = Number(document.getElementById("deleteSpecificTextBox").value);
+  if (portalNum > 0)
+    if (0 > parseInt(portalNum)) clearData(Math.abs(portalNum));
+    else {
+      for (const [portalID, portalData] of Object.entries(portalSaveData)) {
+        if (portalData.totalPortals === portalNum) delete portalSaveData[portalID];
+      }
+    }
+  savePortalData(true)
+  showHideUnusedGraphs();
+}
+
+// ####### Here begins old code
+function toggleClearButton() {
+  document.getElementById("clrAllDataBtn").disabled = !document.getElementById("clrChkbox").checked;
+}
+
+function toggleDarkGraphs() {
+  function removeDarkGraphs() {
+    var a = document.getElementById("dark-graph.css");
+    a && (document.head.removeChild(a), debug("Removing dark-graph.css file", "graphs"));
+  }
+  function addDarkGraphs() {
+    var a = document.getElementById("dark-graph.css");
+    if (!a) {
+      var b = document.createElement("link");
+      (b.rel = "stylesheet"), (b.type = "text/css"), (b.id = "dark-graph.css"), (b.href = basepath + "dark-graph.css"), document.head.appendChild(b), debug("Adding dark-graph.css file", "graphs");
+    }
+  }
+  if (game) {
+    var c = document.getElementById("dark-graph.css"),
+      d = document.getElementById("blackCB").checked;
+    (!c && (0 == game.options.menu.darkTheme.enabled || 2 == game.options.menu.darkTheme.enabled)) || MODULES.graphs.useDarkAlways || d
+      ? addDarkGraphs()
+      : c && (1 == game.options.menu.darkTheme.enabled || 3 == game.options.menu.darkTheme.enabled || !d) && removeDarkGraphs();
+  }
+}
+// ####### end scary old code
+
+// Graph Selection 
+
 function saveSelectedGraphs() {
-    rememberSelectedVisible = [];
-    for (var b, a = 0; a < chart1.series.length; a++) (b = chart1.series[a]), (rememberSelectedVisible[a] = b.visible);
+  if (!chart1) return;
+  for (let i = 0; i < chart1.series.length; i++) {
+    GRAPHSETTINGS.rememberSelected[i] = chart1.series[i].visible;
+  }
+  saveSetting();
 }
 function applyRememberedSelections() {
-    for (var b, a = 0; a < chart1.series.length; a++) (b = chart1.series[a]), !1 == rememberSelectedVisible[a] && b.hide();
+  for (let i = 0; i < chart1.series.length; i++) {
+    if (!GRAPHSETTINGS.rememberSelected[i]) { chart1.series[i].hide(); }
+  }
 }
 function toggleSpecificGraphs() {
-    for (var b, a = 0; a < chart1.series.length; a++) (b = chart1.series[a]), b.visible ? b.hide() : b.show();
+  for (const chart of chart1.series) {
+    chart.visible ? chart.hide() : chart.show();
+  }
 }
+// toggle all graphs to the opposite of the average visible/hidden state
 function toggleAllGraphs() {
-    for (var c, a = 0, b = 0; b < chart1.series.length; b++) (c = chart1.series[b]), c.visible && a++;
-    for (var c, b = 0; b < chart1.series.length; b++) (c = chart1.series[b]), a > chart1.series.length / 2 ? c.hide() : c.show();
+  let visCount = 0;
+  chart1.series.forEach(chart => visCount += chart.visible)
+  for (const chart of chart1.series) {
+    visCount > chart1.series.length / 2 ? chart.hide() : chart.show();
+  }
 }
-/*function clearData(portal,clrall) {
-    if(!portal)
-        portal = 0;
-    if (!clrall) {
-        while(allSaveData[0].totalPortals < getTotalPortals(true) - portal) {
-            allSaveData.shift();
-        }
-    } else {
-        while(allSaveData[0].totalPortals != game.global.totalPortals) {
-            allSaveData.shift();
-        }
-    }
-}*/
-function clearData(portal, clrall = false) {
-    if (clrall) {
-        var currentPortalNumber = getTotalPortals(true);
-        while (allSaveData[0].totalPortals != currentPortalNumber) {
-            allSaveData.shift();
-        }
-    } else {
-        var keepSaveDataIndex = allSaveData.length - 1;
-        for (var i = 0; i <= portal; i++) {
-            keepSaveDataIndex -= allSaveData[keepSaveDataIndex].world;
-            if (keepSaveDataIndex <= 0) {
-                return;
-            }
-        }
 
-        allSaveData.splice(0, keepSaveDataIndex + 1);
-    }
-    showHideUnusedGraphs();
-}
-function deleteSpecific() {
-    var a = document.getElementById("deleteSpecificTextBox").value;
-    if ("" != a)
-        if (0 > parseInt(a)) clearData(Math.abs(a));
-        else for (var b = allSaveData.length - 1; 0 <= b; b--) allSaveData[b].totalPortals == a && allSaveData.splice(b, 1);
-	showHideUnusedGraphs();
-}
+// MORE SCARY OLD CODE
+// show graph window
 function autoToggleGraph() {
-    game.options.displayed && toggleSettingsMenu();
-    var a = document.getElementById("autoSettings");
-    a && "block" === a.style.display && (a.style.display = "none");
-    var a = document.getElementById("autoTrimpsTabBarMenu");
-    a && "block" === a.style.display && (a.style.display = "none");
-    var b = document.getElementById("graphParent");
-    "block" === b.style.display ? (b.style.display = "none") : ((b.style.display = "block"), setGraph());
+  game.options.displayed && toggleSettingsMenu();
+  var a = document.getElementById("autoSettings");
+  a && "block" === a.style.display && (a.style.display = "none");
+  var a = document.getElementById("autoTrimpsTabBarMenu");
+  a && "block" === a.style.display && (a.style.display = "none");
+  var b = document.getElementById("graphParent");
+  "block" === b.style.display ? (b.style.display = "none") : ((b.style.display = "block")); // , displayGraph()
 }
+
+// focus main game
 function escapeATWindows() {
-    var a = document.getElementById("tooltipDiv");
-    if ("none" != a.style.display) return void cancelTooltip();
-    game.options.displayed && toggleSettingsMenu();
-    var b = document.getElementById("autoSettings");
-    "block" === b.style.display && (b.style.display = "none");
-    var b = document.getElementById("autoTrimpsTabBarMenu");
-    "block" === b.style.display && (b.style.display = "none");
-    var c = document.getElementById("graphParent");
-    "block" === c.style.display && (c.style.display = "none");
+  var a = document.getElementById("tooltipDiv");
+  if ("none" != a.style.display) return void cancelTooltip();
+  game.options.displayed && toggleSettingsMenu();
+  var b = document.getElementById("autoSettings");
+  "block" === b.style.display && (b.style.display = "none");
+  var b = document.getElementById("autoTrimpsTabBarMenu");
+  "block" === b.style.display && (b.style.display = "none");
+  var c = document.getElementById("graphParent");
+  "block" === c.style.display && (c.style.display = "none");
 }
 document.addEventListener(
-    "keydown",
-    function (a) {
-        1 != game.options.menu.hotkeys.enabled || game.global.preMapsActive || game.global.lockTooltip || ctrlPressed || heirloomsShown || 27 != a.keyCode || escapeATWindows();
-    },
-    !0
+  "keydown",
+  function (a) {
+    1 != game.options.menu.hotkeys.enabled || game.global.preMapsActive || game.global.lockTooltip
+      || ctrlPressed || heirloomsShown || 27 != a.keyCode || escapeATWindows();
+  },
+  true
 );
-function getTotalDarkEssenceCount() {
-    return game.global.spentEssence + game.global.essence;
-}
+
+// ####### end scary old code
+
+function getportalID() { return `u${getGameData.universe()} p${getTotalPortals()}` }
 
 function pushData() {
-    debug("Starting Zone " + game.global.world, "graphs");
-    var getPercent = (game.stats.heliumHour.value() / (game.global.totalHeliumEarned - (game.global.heliumLeftover + game.resources.helium.owned))) * 100;
-    var lifetime = (game.resources.helium.owned / (game.global.totalHeliumEarned - game.resources.helium.owned)) * 100;
-    var RgetPercent = (game.stats.heliumHour.value() / (game.global.totalRadonEarned - (game.global.radonLeftover + game.resources.radon.owned))) * 100;
-    var Rlifetime = (game.resources.radon.owned / (game.global.totalRadonEarned - game.resources.radon.owned)) * 100;
-
-	if (game.global.challengeActive === 'Daily') {
-		var dailyString = getCurrentChallengePane().split('.');
-		var dailyDate = dailyString[0].substr(13).slice(0, 16);
-	}
-    allSaveData.push({
-        totalPortals: getTotalPortals(true),
-        currentTime: new Date().getTime(),
-        portalTime: game.global.portalTime,
-        world: game.global.world,
-	challenge: game.global.challengeActive === 'Daily' ? dailyDate : game.global.challengeActive,
-        voids: game.global.totalVoidMaps,
-        heirlooms: { value: game.stats.totalHeirlooms.value, valueTotal: game.stats.totalHeirlooms.valueTotal },
-        nullifium: recycleAllExtraHeirlooms(true),
-        coord: game.upgrades.Coordination.allowed - game.upgrades.Coordination.done,
-        lastwarp: game.global.lastWarp,
-        essence: getTotalDarkEssenceCount(),
-        heliumOwned: game.resources.helium.owned,
-        hehr: getPercent.toFixed(4),
-        helife: lifetime.toFixed(4),
-        overkill: GraphsVars.OVKcellsInWorld,
-        zonetime: GraphsVars.ZoneStartTime,
-        mapbonus: GraphsVars.MapBonus,
-        magmite: game.global.magmite,
-        magmamancers: game.jobs.Magmamancer.owned,
-        fluffy: game.global.fluffyExp,
-        scruffy: game.global.fluffyExp2,
-        nursery: game.buildings.Nursery.purchased,
-        smithies: game.buildings.Smithy.owned,
-        amals: game.jobs.Amalgamator.owned,
-        radonOwned: game.resources.radon.owned,
-        rnhr: RgetPercent.toFixed(4),
-        rnlife: Rlifetime.toFixed(4),
-        s3: game.global.lastRadonPortal,
-	worshippers: game.jobs.Worshipper.owned,
-        bonfires: game.challenges.Hypothermia.bonfires,
-        embers: game.challenges.Hypothermia.embers,
-        wonders: game.challenges.Experience.wonders,
-        empower: game.global.challengeActive == "Daily" && typeof game.global.dailyChallenge.empower !== "undefined" ? game.global.dailyChallenge.empower.stacks : 0,
-        cruffys: game.challenges.Nurture.level,
-        universe: game.global.universe,
-        universeSelection: document.getElementById('universeSelection').options[document.getElementById('universeSelection').options.selectedIndex].value,
-        u1graphSelection: document.getElementById('u1graphSelection').options[document.getElementById('u1graphSelection').options.selectedIndex].value,
-        u2graphSelection: document.getElementById('u2graphSelection').options[document.getElementById('u2graphSelection').options.selectedIndex].value,
-    });
-    clearData(10);
-    safeSetItems("allSaveData", JSON.stringify(allSaveData));
-    showHideUnusedGraphs();
+  //debug("Starting Zone " + getGameData.world(), "graphs");
+  const portalID = getportalID();
+  if (!portalSaveData[portalID] || getGameData.world() === 1) { // reset portal data if restarting a portal
+    savePortalData(true) // save old portal to history
+    portalSaveData[portalID] = new Portal();
+  }
+  portalSaveData[portalID].update();
+  clearData(50); // Safety value, probably too high
+  savePortalData(false) // save current portal
 }
 
+// Hide graphs that have no collected data
 function showHideUnusedGraphs() {
-    // Hide challenge graphs that are not in the saved data
-    const graphedChallenges = [...new Set(allSaveData.map((data) => data = data.challenge))];
-    const perChallengeGraphs = {Hypothermia: {graphs: ["Bonfires", "Embers"], universe: "u2"},
-                                Nurture: {graphs: ["Cruffys"], universe: "u2"},
-                                Experience: {graphs: ["Wonders"], universe: "u1"}};
-    for (const [challenge, data] of Object.entries(perChallengeGraphs)) {
-        const graphs = data.graphs;
-        const style = graphedChallenges.includes(challenge) ? "" : "none";
-        graphs.forEach((graph) => { document.querySelector(`#${data.universe}graphSelection [value=${graph}]`).style.display = style; })
-    }
-    // Hide specific graphs that are constant (either not unlocked yet, or maxed)
-    const emptyGraphs = {OverkillCells: {dataName: "overkill"},
-                         Worshippers: {universe: "u2"}, 
-                         "Fluffy XP": {dataName: "fluffy", universe: "u1"}, 
-                         "Fluffy XP PerHour": {dataName: "fluffy", universe: "u1"},
-                         Amalgamators: {dataName: "amals", universe: "u1"}, 
-                         Empower: {},
-                         }
-    for (const [graphName, data] of Object.entries(emptyGraphs)) {
-        const dataName = data.dataName ? data.dataName : graphName.toLowerCase();
-        const universes = data.universe ? [data.universe] : ["u1", "u2"]
-        for (universe of universes) {
-            const style = [...new Set(allSaveData.map((graphs) => graphs = graphs[dataName]))].length == 1 ? "none" : "";
-            document.querySelector(`#${universe}graphSelection [value="${graphName}"]`).style.display = style;
+  for (const graph of graphList) {
+    let style = "none"
+    if (graph.graphType != "line") continue;
+    const universes = graph.universe ? [graph.universe] : [1, 2]
+    for (const universe of universes) {
+      for (portal of Object.values(portalSaveData)) {
+        if (portal.perZoneData[graph.dataVar] && portal.universe == universe  // has collected data, in the right universe
+          && portal.perZoneData[graph.dataVar].some((z) => { return !(z === 0 || z === null) })) { // and there is nonzero data
+          style = ""
+          break;
         }
+      }
+      document.querySelector(`#u${universe}graphSelection [value="${graph.selectorText}"]`).style.display = style;
+    }
+  }
+}
 
+function loadGraphData() {
+  var loadedData = LZString.decompressFromBase64(localStorage.getItem("portalDataHistory"));
+  var currentPortal = JSON.parse(localStorage.getItem("portalDataCurrent"));
+  if (loadedData != "") {
+    var loadedData = JSON.parse(loadedData);
+    if (currentPortal) { loadedData[Object.keys(currentPortal)[0]] = Object.values(currentPortal)[0] }
+    console.log("Graphs: Found portalSaveData")
+    // remake object structure
+    for (const [portalID, portalData] of Object.entries(loadedData)) {
+      portalSaveData[portalID] = new Portal();
+      for (const [k, v] of Object.entries(portalData)) {
+        portalSaveData[portalID][k] = v;
+      }
     }
+  }
+  loadedSettings = JSON.parse(localStorage.getItem("GRAPHSETTINGS"));
+  if (loadedSettings !== null) GRAPHSETTINGS = loadedSettings;
+  MODULES.graphs = {}
+  MODULES.graphs.useDarkAlways = false
 }
-var graphAnal = [];
-function trackHourlyGraphAnalytics() {
-    graphAnal.push({
-        currentTime: new Date().getTime(),
-        totalPortals: getTotalPortals(true),
-        heliumOwned: game.resources.helium.owned,
-        radonOwned: game.resources.radon.owned,
-        highzone: game.global.highestLevelCleared,
-        bones: game.global.b,
-    }),
-        safeSetItems("graphAnal", JSON.stringify(graphAnal));
-}
-trackHourlyGraphAnalytics();
-setInterval(trackHourlyGraphAnalytics, 3600000);
-function initializeData() {
-    null === allSaveData && (allSaveData = []), 0 === allSaveData.length && pushData();
-}
-var GraphsVars = {};
-function InitGraphsVars() {
-    (GraphsVars.currentPortal = 0),
-    (GraphsVars.OVKcellsInWorld = 0),
-    (GraphsVars.lastOVKcellsInWorld = 0),
-    (GraphsVars.currentworld = 0),
-    (GraphsVars.lastrunworld = 0),
-    (GraphsVars.aWholeNewWorld = !1),
-    (GraphsVars.lastZoneStartTime = 0),
-    (GraphsVars.ZoneStartTime = 0),
-    (GraphsVars.MapBonus = 0),
-    (GraphsVars.aWholeNewPortal = 0),
-    (GraphsVars.currentPortal = 0)
-    if (allSaveData.length > 0) {
-        if (allSaveData[allSaveData.length-1].universeSelection !== undefined)
-            document.getElementById('universeSelection').value = allSaveData[allSaveData.length-1].universeSelection
-        if (allSaveData[allSaveData.length-1].u1graphSelection !== undefined)
-            document.getElementById('u1graphSelection').value = allSaveData[allSaveData.length-1].u1graphSelection
-        if (allSaveData[allSaveData.length-1].u2graphSelection !== undefined)
-            document.getElementById('u2graphSelection').value = allSaveData[allSaveData.length-1].u2graphSelection
-    }      
-};
-InitGraphsVars();
 
-function gatherInfo() {
-    if (game.options.menu.pauseGame.enabled) return;
-    initializeData();
-    GraphsVars.aWholeNewPortal = GraphsVars.currentPortal != getTotalPortals(true);
-    if (GraphsVars.aWholeNewPortal) {
-        GraphsVars.currentPortal = getTotalPortals(true);
-        filteredLoot = {
-            produced: {
-                metal: 0,
-                wood: 0,
-                food: 0,
-                gems: 0,
-                fragments: 0,
-            },
-            looted: {
-                metal: 0,
-                wood: 0,
-                food: 0,
-                gems: 0,
-                fragments: 0,
-            },
-        };
+
+// Custom Function Helpers
+// diff between x and x-1, or x and initial
+function diff(dataVar, initial) {
+  return function (portal, i) {
+    let e1 = portal.perZoneData[dataVar][i];
+    let e2 = initial ? initial : portal.perZoneData[dataVar][i - 1];
+    if (e1 === null || e2 === null) return null;
+    return e1 - e2
+  }
+}
+
+const formatters = {
+  datetime: function () {
+    let ser = this.series;
+    return '<span style="color:' + ser.color + '" >●</span> ' + ser.name + ": <b>" + formatDuration(this.y / 1000) + "</b><br>";
+  },
+}
+
+// Create all the Graph objects
+// Graph(dataVar, universe, selectorText, additionalParams)
+// additionalParams == graphTitle, conditional, customFunction, useAccumulator, toggles, xTitle, yTitle, formatter
+
+// To add a new graph, add it to graphList with the desired options,
+// If using a new dataVar, add that to getGameData
+
+// Toggles are perHr, lifetime, s3normalized
+// To make a new toggle, add the switch case and title mod to Graph.lineGraph
+
+const graphList = [
+  // U1 Graphs
+  ["heliumOwned", 1, "Helium", {
+    toggles: ["perHr", "lifetime"]
+  }],
+  ["fluffy", 1, "Fluffy", {
+    graphTitle: "Fluffy Exp",
+    conditional: () => { return getGameData.u1hze() >= 300 && getGameData.fluffy() < 3415819248011889 }, // pre unlock, post E10L10
+    customFunction: (portal, i) => { return diff("fluffy", portal.initialFluffy)(portal, i) },
+    toggles: ["perHr"]
+  }],
+  ["amals", 1, "Amalgamators"],
+  ["wonders", 1, "Wonders", {
+    conditional: () => { return getGameData.challengeActive() === "Experience" }
+  }],
+
+  // U2 Graphs
+  ["radonOwned", 2, "Radon", {
+    toggles: ["perHr", "lifetime", "s3normalized"]
+  }],
+  ["scruffy", 2, "Scruffy", {
+    graphTitle: "Scruffy Exp",
+    customFunction: (portal, i) => { return diff("scruffy", portal.initialScruffy)(portal, i) },
+    toggles: ["perHr"]
+  }],
+  ["worshippers", 2, "Worshippers", {
+    conditional: () => { return getGameData.u2hze() >= 50 }
+  }],
+  ["smithies", 2, "Smithies"],
+  ["bonfires", 2, "Bonfires", {
+    graphTitle: "Active Bonfires",
+    conditional: () => { return getGameData.challengeActive() === "Hypothermia" }
+  }],
+  ["embers", 2, "Embers", {
+    conditional: () => { return getGameData.challengeActive() === "Hypothermia" }
+  }],
+  ["cruffys", 2, "Cruffys", {
+    conditional: () => { return getGameData.challengeActive() === "Nurture" }
+  }],
+
+  // Generic Graphs
+  ["voids", false, "Void Map History", {
+    graphTitle: "Void Map History (voids finished during the same level acquired are not counted/tracked)",
+    yTitle: "Number of Void Maps",
+  }],
+  [false, false, "Total Voids", {
+    portalVar: "totalVoidMaps",
+    graphType: "column",
+    graphTitle: "Total Void Maps Run"
+  }],
+  [false, false, "Nullifium Gained", {
+    portalVar: "totalNullifium",
+    graphType: "column",
+  }],
+  ["coord", false, "Coordinations", {
+    graphTitle: "Unbought Coordinations",
+  }],
+  ["overkill", false, "Overkill Cells", {
+    // Overkill unlock zones (roughly)
+    conditional: () => {
+      return ((getGameData.universe() == 1 && getGameData.u1hze() >= 170)
+        || getGameData.universe() == 2 && getGameData.u2hze() >= 201)
     }
-    GraphsVars.aWholeNewWorld = GraphsVars.currentworld != game.global.world;
-    if (GraphsVars.aWholeNewWorld) {
-        GraphsVars.currentworld = game.global.world;
-        if (allSaveData.length > 0 && allSaveData[allSaveData.length - 1].world != game.global.world) {
-            pushData();
-        }
-        GraphsVars.OVKcellsInWorld = 0;
-        GraphsVars.ZoneStartTime = 0;
-        GraphsVars.MapBonus = 0;
-    }
+  }],
+  ["currentTime", false, "Clear Time", {
+    customFunction: (portal, i) => { return Math.round(diff("currentTime")(portal, i) / 100) * 100 },
+    yType: "datetime",
+    formatter: formatters.datetime
+  }],
+  ["currentTime", false, "Cumulative Clear Time", {
+    customFunction: (portal, i) => { return Math.round(diff("currentTime", portal.portalTime)(portal, i)) },
+    yType: "datetime",
+    formatter: formatters.datetime
+  }],
+  ["mapbonus", false, "Map Bonus"],
+  ["empower", false, "Empower", {
+    conditional: () => { return getGameData.challengeActive() === "Daily" && typeof game.global.dailyChallenge.empower !== "undefined" }
+  }]
+].map(opts => new Graph(...opts));
+
+const getGameData = {
+  currentTime: () => { return new Date().getTime() },
+  world: () => { return game.global.world },
+  challengeActive: () => { return game.global.challengeActive },
+  voids: () => { return game.global.totalVoidMaps },
+  totalVoids: () => { return game.stats.totalVoidMaps.value },
+  nullifium: () => { return recycleAllExtraHeirlooms(true) },
+  coord: () => { return game.upgrades.Coordination.allowed - game.upgrades.Coordination.done },
+  overkill: () => {
+    // overly complex check for Liq, overly fragile check for overkill cells
     if (game.options.menu.overkillColor.enabled == 0) toggleSetting("overkillColor");
     if (game.options.menu.liquification.enabled && game.talents.liquification.purchased && !game.global.mapsActive && game.global.gridArray && game.global.gridArray[0] && game.global.gridArray[0].name == "Liquimp")
-        GraphsVars.OVKcellsInWorld = 100;
-    else GraphsVars.OVKcellsInWorld = document.getElementById("grid").getElementsByClassName("cellColorOverkill").length;
-    GraphsVars.ZoneStartTime = new Date().getTime() - game.global.zoneStarted;
-    GraphsVars.MapBonus = game.global.mapBonus;
+      return 100;
+    else return document.getElementById("grid").getElementsByClassName("cellColorOverkill").length;
+  },
+  zoneTime: () => { return new Date().getTime() - game.global.zoneStarted },
+  mapbonus: () => { return game.global.mapBonus },
+  empower: () => { return game.global.challengeActive == "Daily" && typeof game.global.dailyChallenge.empower !== "undefined" ? game.global.dailyChallenge.empower.stacks : 0 },
+  lastwarp: () => { return game.global.lastWarp },
+  essence: () => { return game.global.spentEssence + game.global.essence },
+  heliumOwned: () => { return game.resources.helium.owned },
+  magmite: () => { return game.global.magmite },
+  magmamancers: () => { return game.jobs.Magmamancer.owned },
+  fluffy: () => { return game.global.fluffyExp },
+  nursery: () => { return game.buildings.Nursery.purchased },
+  amals: () => { return game.jobs.Amalgamator.owned },
+  wonders: () => { return game.challenges.Experience.wonders },
+  scruffy: () => { return game.global.fluffyExp2 },
+  smithies: () => { return game.buildings.Smithy.owned },
+  radonOwned: () => { return game.resources.radon.owned },
+  worshippers: () => { return game.jobs.Worshipper.owned },
+  bonfires: () => { return game.challenges.Hypothermia.bonfires },
+  embers: () => { return game.challenges.Hypothermia.embers },
+  cruffys: () => { return game.challenges.Nurture.level },
+  universe: () => { return game.global.universe },
+  portalTime: () => { return game.global.portalTime },
+  s3: () => { return game.global.lastRadonPortal },
+  u1hze: () => { return game.global.highestLevelCleared },
+  u2hze: () => { return game.global.highestRadonLevelCleared },
 }
 
-var dataBase = {};
-var databaseIndexEntry = {
-    Index: 0,
-    Portal: 0,
-    Challenge: 0,
-    World: 0,
-};
-var databaseDirtyEntry = {
-    State: false,
-    Reason: "",
-    Index: -1,
-};
-var portalExistsArray = [];
-var portalRunArray = [];
-var portalRunIndex = 0;
-
-function chkdsk() {
-    rebuildDataIndex(), checkIndexConsistency(), checkWorldSequentiality(), !0 == databaseDirtyEntry.State;
-}
-function rebuildDataIndex() {
-    for (var a = 0; a < allSaveData.length - 1; a++)
-        (dataBase[a] = { Index: a, Portal: allSaveData[a].totalPortals, Challenge: allSaveData[a].challenge, World: allSaveData[a].world }),
-            portalRunArray.push({ Index: a, Portal: allSaveData[a].totalPortals, Challenge: allSaveData[a].challenge }),
-            "undefined" == typeof portalExistsArray[allSaveData[a].totalPortals]
-                ? (portalExistsArray[allSaveData[a].totalPortals] = { Exists: !0, Row: portalRunIndex, Index: a, Challenge: allSaveData[a].challenge })
-                : ((databaseDirtyFlag.State = !0), (databaseDirtyFlag.Reason = "oreoportal"), (databaseDirtyFlag.Index = a), (row = portalExistsArray[allSaveData[a].totalPortals].Row)),
-            portalRunIndex++;
-}
-function checkIndexConsistency() {
-    for (var a = 0; a < dataBase.length - 1; a++)
-        if (dataBase[a].Index != a) {
-            databaseDirtyFlag = [!0, "index", a];
-            break;
-        }
-}
-function checkWorldSequentiality() {
-    for (var a, b, c, d = 1; d < dataBase.length - 1; d++) {
-        if (((lastworldEntry = dataBase[d - 1]), (currentworldEntry = dataBase[d]), (nextworldEntry = dataBase[d + 1]), (a = lastworldEntry.World), (b = currentworldEntry.World), (c = nextworldEntry.World), a > b && 1 != b)) {
-            (databaseDirtyFlag.State = !0), (databaseDirtyFlag.Reason = "descending"), (databaseDirtyFlag.Index = d);
-            break;
-        }
-        if (a > b && 1 == b && a == c) {
-            (databaseDirtyFlag.State = !0), (databaseDirtyFlag.Reason = "badportal"), (databaseDirtyFlag.Index = d);
-            break;
-        }
-    }
-}
-function drawGraph(a, b, refresh) {
-    var universe = document.getElementById('universeSelection').options[document.getElementById('universeSelection').options.selectedIndex].value;
-    if (universe == 'Universe 1') {
-        document.getElementById('u1graphSelection').style.display = ''
-        document.getElementById('u2graphSelection').style.display = 'none'
-    }
-    if (universe == 'Universe 2') {
-        document.getElementById('u1graphSelection').style.display = 'none'
-        document.getElementById('u2graphSelection').style.display = ''
-    }
-    var c = universe == 'Universe 1' ? document.getElementById("u1graphSelection") : universe == 'Universe 2' ? document.getElementById("u2graphSelection") : "Universe 1";
-    if (a === undefined && b === undefined && c.value !== undefined && refresh !== undefined) {
-        setGraphData('Refresh');
-        setGraphData(c.value);
-    }
-    a ? (c.selectedIndex--, 0 > c.selectedIndex && (c.selectedIndex = 0)) : b && c.selectedIndex != c.options.length - 1 && c.selectedIndex++, setGraphData(c.value);
-}
-
-function setGraphData(graph) {
-    var title,
-        xTitle,
-        yTitle,
-        yType,
-        valueSuffix,
-        series,
-        formatter,
-        xminFloor = 1,
-        yminFloor = null;
-    var precision = 0;
-    var oldData = JSON.stringify(graphData);
-    valueSuffix = "";
-
-    switch (graph) {
-        case "Refresh":
-            graphData = [];
-            
-            title = "Refresh";
-            xTitle = "Refresh";
-            yTitle = "Refresh";
-            yType = "Linear";
-            break;
-        case "Void Maps":
-            var currentPortal = -1;
-            var totalVoids = 0;
-            var theChallenge = "";
-            graphData = [];
-            for (var i in allSaveData) {
-                if (allSaveData[i].totalPortals != currentPortal) {
-                    if (currentPortal == -1) {
-                        theChallenge = allSaveData[i].challenge;
-                        currentPortal = allSaveData[i].totalPortals;
-                        graphData.push({
-                            name: "Void Maps",
-                            data: [],
-                            type: "column",
-                        });
-                        continue;
-                    }
-                    graphData[0].data.push([allSaveData[i - 1].totalPortals, totalVoids]);
-                    theChallenge = allSaveData[i].challenge;
-                    totalVoids = 0;
-                    currentPortal = allSaveData[i].totalPortals;
-                }
-                if (allSaveData[i].voids > totalVoids) {
-                    totalVoids = allSaveData[i].voids;
-                }
-            }
-            title = "Void Maps (completed)";
-            xTitle = "Portal";
-            yTitle = "Number of Void Maps";
-            yType = "Linear";
-            break;
-
-        case "Nullifium Gained":
-            var currentPortal = -1;
-            var totalNull = 0;
-            var theChallenge = "";
-            graphData = [];
-            var averagenulli = 0;
-            var sumnulli = 0;
-            var count = 0;
-            for (var i in allSaveData) {
-                if (allSaveData[i].totalPortals != currentPortal) {
-                    if (currentPortal == -1) {
-                        theChallenge = allSaveData[i].challenge;
-                        currentPortal = allSaveData[i].totalPortals;
-                        graphData.push({
-                            name: "Nullifium Gained",
-                            data: [],
-                            type: "column",
-                        });
-                        continue;
-                    }
-                    graphData[0].data.push([allSaveData[i - 1].totalPortals, totalNull]);
-                    count++;
-                    sumnulli += totalNull;
-                    theChallenge = allSaveData[i].challenge;
-                    totalNull = 0;
-                    currentPortal = allSaveData[i].totalPortals;
-                }
-                if (allSaveData[i].nullifium > totalNull) {
-                    totalNull = allSaveData[i].nullifium;
-                }
-            }
-            averagenulli = sumnulli / count;
-            title = "Nullifium Gained Per Portal";
-            if (averagenulli) title = "Average " + title + " = " + averagenulli;
-            xTitle = "Portal";
-            yTitle = "Nullifium Gained";
-            yType = "Linear";
-            break;
-
-        case "Loot Sources":
-            graphData = [];
-            graphData[0] = {
-                name: "Metal",
-                data: lootData.metal,
-            };
-            graphData[1] = {
-                name: "Wood",
-                data: lootData.wood,
-            };
-            graphData[2] = {
-                name: "Food",
-                data: lootData.food,
-            };
-            graphData[3] = {
-                name: "Gems",
-                data: lootData.gems,
-            };
-            graphData[4] = {
-                name: "Fragments",
-                data: lootData.fragments,
-            };
-            title = "Current Loot Sources (of all resources gained) - for the last 15 minutes";
-            xTitle = "Time (every 15 seconds)";
-            yTitle = "Ratio of looted to gathered";
-            valueSuffix = "%";
-            formatter = function () {
-                return Highcharts.numberFormat(this.y, 3);
-            };
-            break;
-
-        case "Clear Time #2":
-            graphData = allPurposeGraph("cleartime2", true, null, function specialCalc(e1, e2) {
-                return Math.round(e1.zonetime / 1000);
-            });
-            title = "(#2) Time to Clear Zone";
-            xTitle = "Zone";
-            yTitle = "Clear Time";
-            yType = "Linear";
-            valueSuffix = " Seconds";
-            break;
-        case "Clear Time":
-            graphData = allPurposeGraph("cleartime1", true, null, function specialCalc(e1, e2) {
-                return Math.round((e1.currentTime - e2.currentTime - (e1.portalTime - e2.portalTime)) / 1000);
-            });
-            title = "Time to clear zone";
-            xTitle = "Zone";
-            yTitle = "Clear Time";
-            yType = "Linear";
-            valueSuffix = " Seconds";
-            yminFloor = 0;
-            break;
-        case "Cumulative Clear Time #2":
-            graphData = allPurposeGraph(
-                "cumucleartime2",
-                true,
-                null,
-                function specialCalc(e1, e2) {
-                    return Math.round(e1.zonetime);
-                },
-                true
-            );
-            title = "(#2) Cumulative Time (at END of zone#)";
-            xTitle = "Zone";
-            yTitle = "Cumulative Clear Time";
-            yType = "datetime";
-            formatter = function () {
-                var ser = this.series;
-                return '<span style="color:' + ser.color + '" >●</span> ' + ser.name + ": <b>" + Highcharts.dateFormat("%H:%M:%S", this.y) + "</b><br>";
-            };
-            yminFloor = 0;
-            break;
-        case "Cumulative Clear Time":
-            graphData = allPurposeGraph(
-                "cumucleartime1",
-                true,
-                null,
-                function specialCalc(e1, e2) {
-                    return Math.round(e1.currentTime - e2.currentTime - (e1.portalTime - e2.portalTime));
-                },
-                true
-            );
-            title = "Cumulative Time (at END of zone#)";
-            xTitle = "Zone";
-            yTitle = "Cumulative Clear Time";
-            yType = "datetime";
-            formatter = function () {
-                var ser = this.series;
-                return '<span style="color:' + ser.color + '" >●</span> ' + ser.name + ": <b>" + Highcharts.dateFormat("%H:%M:%S", this.y) + "</b><br>";
-            };
-            yminFloor = 0;
-            break;
-
-        case "Helium - He/Hr":
-            graphData = allPurposeGraph("heliumhr", true, null, function specialCalc(e1, e2) {
-                return Math.floor(e1.heliumOwned / ((e1.currentTime - e1.portalTime) / 3600000));
-            });
-            title = "Helium/Hour (Cumulative)";
-            xTitle = "Zone";
-            yTitle = "Helium/Hour";
-            yType = "Linear";
-            yminFloor = 0;
-            precision = 2;
-            break;
-        case "Helium - Total":
-            graphData = allPurposeGraph("heliumOwned", true, null, function specialCalc(e1, e2) {
-                return Math.floor(e1.heliumOwned);
-            });
-            title = "Helium (Lifetime Total)";
-            xTitle = "Zone";
-            yTitle = "Helium";
-            yType = "Linear";
-            break;
-        case "HeHr % / LifetimeHe":
-            graphData = allPurposeGraph("hehr", true, "string");
-            title = "He/Hr % of LifetimeHe";
-            xTitle = "Zone";
-            yTitle = "He/Hr % of LifetimeHe";
-            yType = "Linear";
-            yminFloor = 0;
-            precision = 4;
-            break;
-        case "He % / LifetimeHe":
-            graphData = allPurposeGraph("helife", true, "string");
-            title = "He % of LifetimeHe";
-            xTitle = "Zone";
-            yTitle = "He % of LifetimeHe";
-            yType = "Linear";
-            yminFloor = 0;
-            precision = 4;
-            break;
-        case "Radon - Rn/Hr":
-            graphData = allPurposeGraph("radonhr", true, null, function specialCalc(e1, e2) {
-                return Math.floor(e1.radonOwned / ((e1.currentTime - e1.portalTime) / 3600000));
-            });
-            title = "Radon/Hour (Cumulative)";
-            xTitle = "Zone";
-            yTitle = "Radon/Hour";
-            yType = "Linear";
-            yminFloor = 0;
-            precision = 2;
-            break;
-        case "Radon - Rn/Hr Normalized":
-            graphData = allPurposeGraph("radonhr", true, null, function specialCalc(e1, e2) {
-                return Math.floor(e1.radonOwned / 1.03**e1.s3 / ((e1.currentTime - e1.portalTime) / 3600000));
-            });
-            title = "Radon/Hour (Cumulative, S3 Normalized)";
-            xTitle = "Zone";
-            yTitle = "Radon/Hour";
-            yType = "Linear";
-            yminFloor = 0;
-            precision = 2;
-            break;
-        case "Radon - Total":
-            graphData = allPurposeGraph("radonOwned", true, null, function specialCalc(e1, e2) {
-                return Math.floor(e1.radonOwned);
-            });
-            title = "Radon (Lifetime Total)";
-            xTitle = "Zone";
-            yTitle = "Radon";
-            yType = "Linear";
-            break;
-        case "RnHr % / LifetimeRn":
-            graphData = allPurposeGraph("rnhr", true, "string");
-            title = "Rn/Hr % of LifetimeRn";
-            xTitle = "Zone";
-            yTitle = "Rn/Hr % of LifetimeRn";
-            yType = "Linear";
-            yminFloor = 0;
-            precision = 4;
-            break;
-        case "Rn % / LifetimeRn":
-            graphData = allPurposeGraph("rnlife", true, "string");
-            title = "Rn % of LifetimeRn";
-            xTitle = "Zone";
-            yTitle = "Rn % of LifetimeRn";
-            yType = "Linear";
-            yminFloor = 0;
-            precision = 4;
-            break;
-        case "Void Map History":
-            graphData = allPurposeGraph("voids", true, "number");
-            title = "Void Map History (voids finished during the same level acquired (with RunNewVoids) are not counted/tracked)";
-            xTitle = "Zone";
-            yTitle = "Number of Void Maps";
-            yType = "Linear";
-            break;
-        case "Map Bonus":
-            graphData = allPurposeGraph("mapbonus", true, "number");
-            title = "Map Bonus History";
-            xTitle = "Zone";
-            yTitle = "Map Bonus Stacks";
-            yType = "Linear";
-            break;
-        case "Coordinations":
-            graphData = allPurposeGraph("coord", true, "number");
-            title = "Unpurchased Coordinations History";
-            xTitle = "Zone";
-            yTitle = "Coordination";
-            yType = "Linear";
-            break;
-        case "Amalgamators":
-            graphData = allPurposeGraph("amals", true, "number");
-            title = "Amalgamators";
-            xTitle = "Zone";
-            yTitle = "Amalgamators";
-            yType = "Linear";
-            break;
-        case "Fluffy XP":
-            graphData = allPurposeGraph("fluffy", true, "number");
-            title = "Fluffy XP (Lifetime Total)";
-            xTitle = "Zone (starts at 300)";
-            yTitle = "Fluffy XP";
-            yType = "Linear";
-            xminFloor = 300;
-            break;
-        case "Fluffy XP PerHour":
-            var currentPortal = -1;
-            var currentZone = -1;
-            var startFluffy = 0;
-            graphData = [];
-            for (var i in allSaveData) {
-                if (allSaveData[i].totalPortals != currentPortal) {
-                    graphData.push({
-                        name: "Portal " + allSaveData[i].totalPortals + ": " + allSaveData[i].challenge,
-                        data: [],
-                    });
-                    currentPortal = allSaveData[i].totalPortals;
-                    currentZone = 0;
-                    startFluffy = allSaveData[i].fluffy;
-                }
-                if (currentZone != allSaveData[i].world - 1 && i > 0) {
-                    var loop = allSaveData[i].world - 1 - currentZone;
-                    while (loop > 0) {
-                        graphData[graphData.length - 1].data.push(allSaveData[i - 1][item] * 1);
-                        loop--;
-                    }
-                }
-                if (currentZone != 0) {
-                    graphData[graphData.length - 1].data.push(Math.floor((allSaveData[i].fluffy - startFluffy) / ((allSaveData[i].currentTime - allSaveData[i].portalTime) / 3600000)));
-                }
-                currentZone = allSaveData[i].world;
-            }
-            title = "Fluffy XP/Hour (Cumulative)";
-            xTitle = "Zone";
-            yTitle = "Fluffy XP/Hour";
-            yType = "Linear";
-            xminFloor = 1;
-            break;
-        case "Scruffy XP":
-            graphData = allPurposeGraph("scruffy", true, "number");
-            title = "Scruffy XP (Lifetime Total)";
-            xTitle = "Zone";
-            yTitle = "Scruffy XP";
-            yType = "Linear";
-            xminFloor = 0;
-            break;
-        case "Scruffy XP PerHour":
-            var currentPortal = -1;
-            var currentZone = -1;
-            var startScruffy = 0;
-            graphData = [];
-            for (var i in allSaveData) {
-                if (allSaveData[i].totalPortals != currentPortal) {
-                    graphData.push({
-                        name: "Portal " + allSaveData[i].totalPortals + ": " + allSaveData[i].challenge,
-                        data: [],
-                    });
-                    currentPortal = allSaveData[i].totalPortals;
-                    currentZone = 0;
-                    startScruffy = allSaveData[i].scruffy;
-                }
-                if (currentZone != allSaveData[i].world - 1 && i > 0) {
-                    var loop = allSaveData[i].world - 1 - currentZone;
-                    while (loop > 0) {
-                        graphData[graphData.length - 1].data.push(allSaveData[i - 1][item] * 1);
-                        loop--;
-                    }
-                }
-                if (currentZone != 0) {
-                    graphData[graphData.length - 1].data.push(Math.floor((allSaveData[i].scruffy - startScruffy) / ((allSaveData[i].currentTime - allSaveData[i].portalTime) / 3600000)));
-                }
-                currentZone = allSaveData[i].world;
-            }
-            title = "Scruffy XP/Hour (Cumulative)";
-            xTitle = "Zone";
-            yTitle = "Scruffy XP/Hour";
-            yType = "Linear";
-            xminFloor = 1;
-            break;
-        case "OverkillCells":
-            var currentPortal = -1;
-            graphData = [];
-            for (var i in allSaveData) {
-                if (allSaveData[i].totalPortals != currentPortal) {
-                    graphData.push({
-                        name: "Portal " + allSaveData[i].totalPortals + ": " + allSaveData[i].challenge,
-                        data: [],
-                    });
-                    currentPortal = allSaveData[i].totalPortals;
-                    if (allSaveData[i].world == 1 && currentZone != -1) graphData[graphData.length - 1].data.push(0);
-
-                    if (currentZone == -1 || allSaveData[i].world != 1) {
-                        var loop = allSaveData[i].world;
-                        while (loop > 0) {
-                            graphData[graphData.length - 1].data.push(0);
-                            loop--;
-                        }
-                    }
-                }
-                if (currentZone < allSaveData[i].world && currentZone != -1) {
-                    var num = allSaveData[i].overkill;
-                    if (num) graphData[graphData.length - 1].data.push(num);
-                }
-                currentZone = allSaveData[i].world;
-            }
-            title = "Overkilled Cells";
-            xTitle = "Zone";
-            yTitle = "Overkilled Cells";
-            yType = "Linear";
-            break;
-        default:
-            graphData = allPurposeGraph(graph.toLowerCase(), true, "number");
-            title = `${graph} History`;
-            xTitle = "Zone";
-            yTitle = graph;
-            yType = "Linear";
-    }
-
-    function allPurposeGraph(item, extraChecks, typeCheck, funcToRun, useAccumulator) {
-        var currentPortal = -1;
-        var currentZone = 0;
-        var accumulator = 0;
-        graphData = [];
-        for (var i in allSaveData) {
-            if (typeCheck && typeof allSaveData[i][item] != typeCheck) continue;
-            if (allSaveData[i].universe !== undefined) { 
-                if (allSaveData[i].universe != document.getElementById('universeSelection').options[document.getElementById('universeSelection').options.selectedIndex].value.charAt(9)) {
-                    for (var k in graphData) {
-                        if (graphData[k].universe !== undefined && graphData[k].universe != document.getElementById('universeSelection').options[document.getElementById('universeSelection').options.selectedIndex].value.charAt(9)) {
-                            graphData[k].pop({
-                            name: "Portal " + allSaveData[i].totalPortals + ": " + allSaveData[i].challenge,
-                            data: [],
-                        });
-                        }
-                    }
-                    continue;
-                }
-            }
-            if (allSaveData[i].totalPortals != currentPortal) {
-                graphData.push({
-                    name: "Portal " + allSaveData[i].totalPortals + ": " + allSaveData[i].challenge,
-                    data: [],
-                    universe: allSaveData[i].universe,
-                });
-                currentPortal = allSaveData[i].totalPortals;
-                currentZone = 0;
-                if (funcToRun) {
-                    accumulator = 0;
-                    graphData[graphData.length - 1].data.push(0);
-                }
-                continue;
-            }
-            if (extraChecks) {
-                if (currentZone != allSaveData[i].world - 1) {
-                    var loop = allSaveData[i].world - 1 - currentZone;
-                    while (loop > 0) {
-                        graphData[graphData.length - 1].data.push(allSaveData[i - 1][item] * 1);
-                        loop--;
-                    }
-                }
-            }
-            if (funcToRun && !useAccumulator && currentZone != 0) {
-                var num = funcToRun(allSaveData[i], allSaveData[i - 1]);
-                if (num < 0) num = 1;
-                graphData[graphData.length - 1].data.push(num);
-            } else if (funcToRun && useAccumulator && currentZone != 0) {
-                accumulator += funcToRun(allSaveData[i], allSaveData[i - 1]);
-                if (accumulator < 0) accumulator = 1;
-                graphData[graphData.length - 1].data.push(accumulator);
-            } else {
-                if (allSaveData[i][item] >= 0) graphData[graphData.length - 1].data.push(allSaveData[i][item] * 1);
-                else if (extraChecks) graphData[graphData.length - 1].data.push(-1);
-            }
-            currentZone = allSaveData[i].world;
-        }
-        return graphData;
-    }
-    formatter =
-        formatter ||
-        function () {
-            var ser = this.series;
-            return '<span style="color:' + ser.color + '" >●</span> ' + ser.name + ": <b>" + prettify(this.y) + valueSuffix + "</b><br>";
-        };
-    var additionalParams = {};
-    if (oldData != JSON.stringify(graphData)) {
-        saveSelectedGraphs();
-        setGraph(title, xTitle, yTitle, valueSuffix, formatter, graphData, yType, xminFloor, yminFloor, additionalParams);
-    }
-    if (graph == "Loot Sources") {
-        chart1.xAxis[0].tickInterval = 1;
-        chart1.xAxis[0].minorTickInterval = 1;
-    }
-    if (document.getElementById("rememberCB").checked) {
-        applyRememberedSelections();
-    }
-}
-
+// Global vars
 var chart1;
+var lastSave = new Date()
+var GRAPHSETTINGS = {
+  universeSelection: 1,
+  u1graphSelection: null,
+  u2graphSelection: null,
+  rememberSelected: [],
+  toggles: {}
+}
+var portalSaveData = {}
 
-function setGraph(title, xTitle, yTitle, valueSuffix, formatter, series, yType, xminFloor, yminFloor, additionalParams) {
-    chart1 = new Highcharts.Chart({
-        chart: {
-            renderTo: "graph",
-            zoomType: "xy",
-            resetZoomButton: {
-                position: {
-                    align: "right",
-                    verticalAlign: "top",
-                    x: -20,
-                    y: 15,
-                },
-                relativeTo: "chart",
-            },
-        },
-        title: {
-            text: title,
-            x: -20,
-        },
-        plotOptions: {
-            series: {
-                lineWidth: 1,
-                animation: false,
-                marker: {
-                    enabled: false,
-                },
-            },
-        },
-        xAxis: {
-            floor: xminFloor,
-            title: {
-                text: xTitle,
-            },
-        },
-        yAxis: {
-            floor: yminFloor,
-            title: {
-                text: yTitle,
-            },
-            plotLines: [
-                {
-                    value: 0,
-                    width: 1,
-                    color: "#808080",
-                },
-            ],
-            type: yType,
-            dateTimeLabelFormats: {
-                second: "%H:%M:%S",
-                minute: "%H:%M:%S",
-                hour: "%H:%M:%S",
-                day: "%H:%M:%S",
-                week: "%H:%M:%S",
-                month: "%H:%M:%S",
-                year: "%H:%M:%S",
-            },
-        },
-        tooltip: {
-            pointFormatter: formatter,
-            valueSuffix: valueSuffix,
-        },
-        legend: {
-            layout: "vertical",
-            align: "right",
-            verticalAlign: "middle",
-            borderWidth: 0,
-        },
-        series: series,
-        additionalParams,
-    });
+// load and initialize the UI
+loadGraphData();
+init()
+showHideUnusedGraphs()
+var lastTheme = -1;
+
+
+// Wrap the Trimps function for transitioning zones to avoid data loss
+var originalnextWorld = nextWorld;
+nextWorld = function () {
+  try {
+    if (game.options.menu.pauseGame.enabled) return;
+    if (null === portalSaveData) portalSaveData = {};
+    if (getGameData.world()) { pushData(); }
+  }
+  catch (e) {
+    debug("Gather info failed: " + e)
+  }
+  originalnextWorld(...arguments);
 }
 
-function setColor(tmp) {
-    for (var i in tmp) {
-        tmp[i].color = i == tmp.length - 1 ? "#FF0000" : "#90C3D4";
-    }
-    return tmp;
+// Wrap portal function to update on end of run
+var originalactivatePortal = activatePortal;
+activatePortal = function () {
+  try {
+    pushData();
+  }
+  catch (e) {
+    debug("Gather info failed: " + e)
+  }
+  originalactivatePortal(...arguments)
 }
-
-var filteredLoot = {
-    produced: {
-        metal: 0,
-        wood: 0,
-        food: 0,
-        gems: 0,
-        fragments: 0,
-    },
-    looted: {
-        metal: 0,
-        wood: 0,
-        food: 0,
-        gems: 0,
-        fragments: 0,
-    },
-};
-var lootData = {
-    metal: [],
-    wood: [],
-    food: [],
-    gems: [],
-    fragments: [],
-};
-
-function filterLoot(loot, amount, jest, fromGather) {
-    if (loot != "wood" && loot != "metal" && loot != "food" && loot != "gems" && loot != "fragments") return;
-    if (jest) {
-        filteredLoot.produced[loot] += amount;
-        filteredLoot.looted[loot] -= amount;
-    } else if (fromGather) filteredLoot.produced[loot] += amount;
-    else filteredLoot.looted[loot] += amount;
-}
-
-function getLootData() {
-    var loots = ["metal", "wood", "food", "gems", "fragments"];
-    for (var r in loots) {
-        var name = loots[r];
-        if (filteredLoot.produced[name]) lootData[name].push(filteredLoot.looted[name] / filteredLoot.produced[name]);
-        if (lootData[name].length > 60) lootData[name].shift();
-    }
-}
-
-setInterval(getLootData, 15000);
-
-(function () {
-    var resAmts;
-
-    function storeResAmts() {
-        resAmts = {};
-        for (let item in lootData) {
-            resAmts[item] = game.resources[item].owned;
-        }
-    }
-
-    const oldJestimpLoot = game.badGuys.Jestimp.loot;
-    game.badGuys.Jestimp.loot = function () {
-        storeResAmts();
-        var toReturn = oldJestimpLoot.apply(this, arguments);
-        for (let item in resAmts) {
-            var gained = game.resources[item].owned - resAmts[item];
-            if (gained > 0) {
-                filterLoot(item, gained, true);
-            }
-        }
-        return toReturn;
-    };
-
-    const oldChronoimpLoot = game.badGuys.Chronoimp.loot;
-    game.badGuys.Chronoimp.loot = function () {
-        storeResAmts();
-        var toReturn = oldChronoimpLoot.apply(this, arguments);
-        for (let item in resAmts) {
-            var gained = game.resources[item].owned - resAmts[item];
-            if (gained > 0) {
-                filterLoot(item, gained, true);
-            }
-        }
-        return toReturn;
-    };
-
-    const oldFunction = window.addResCheckMax;
-    window.addResCheckMax = (a, b, c, d, e, f) => filterLoot(a, b, null, d, f) || oldFunction(a, b, c, d, e, f);
-})();
-
-function lookUpZoneData(a, b) {
-    null == b && (b = getTotalPortals(true));
-    for (var c = allSaveData.length - 1; 0 <= c; c--) if (allSaveData[c].totalPortals == b && allSaveData[c].world == a) return allSaveData[c];
-}
-
-setInterval(gatherInfo, 100);

--- a/Graphs.js
+++ b/Graphs.js
@@ -856,7 +856,12 @@ const getGameData = {
   s3: () => { return game.global.lastRadonPortal },
   u1hze: () => { return game.global.highestLevelCleared },
   u2hze: () => { return game.global.highestRadonLevelCleared },
-  c23increase: () => { return Math.max(0, getIndividualSquaredReward(game.global.challengeActive, game.global.world) - getIndividualSquaredReward(game.global.challengeActive)) },
+  c23increase: () => {
+    if (game.global.challengeActive !== "" && game.global.runningChallengeSquared) {
+      return Math.max(0, getIndividualSquaredReward(game.global.challengeActive, game.global.world) - getIndividualSquaredReward(game.global.challengeActive));
+    }
+    else { return 0; }
+  },
   cinf: () => { return countChallengeSquaredReward(false, false, true) },
 }
 

--- a/Graphs.js
+++ b/Graphs.js
@@ -152,7 +152,7 @@ function Graph(dataVar, universe, selectorText, additionalParams = {}) {
   this.dataVar = dataVar
   this.universe = universe; // false, 1, 2
   this.selectorText = selectorText ? selectorText : dataVar;
-  this.id = selectorText.replaceAll(" ", "_")
+  this.id = selectorText.replace(/ /g, "_")
   this.graphTitle = this.selectorText;
   this.graphType = "line"
   this.customFunction;

--- a/Graphs.js
+++ b/Graphs.js
@@ -161,6 +161,10 @@ const formatters = {
   }
 }
 
+function last(arr) {
+  return arr[arr.length - 1]
+}
+
 // --------- User Interface --------- 
 
 // Create all of the UI elements and load in scripts needed
@@ -504,7 +508,7 @@ function Graph(dataVar, universe, selectorText, additionalParams = {}) {
             debug(`Error graphing data on: ${item} ${toggle}, ${e.message}`)
           }
         }
-        if (this.useAccumulator) x += cleanData.at(-1) !== undefined ? cleanData.at(-1)[1] : 0;
+        if (this.useAccumulator) { x += last(cleanData) !== undefined ? last(cleanData)[1] : 0; }
         if (this.typeCheck && typeof x != this.typeCheck) x = null;
         cleanData.push([Number(index), x]) // highcharts expects number, number, not str, number
       }
@@ -544,10 +548,10 @@ function Graph(dataVar, universe, selectorText, additionalParams = {}) {
         if (portal.universe != GRAPHSETTINGS.universeSelection) continue;
         let data;
         if (portal[column.dataVar]) data = portal[column.dataVar];
-        if (portal.perZoneData[column.dataVar]) data = portal.perZoneData[column.dataVar].at(-1);
+        if (portal.perZoneData[column.dataVar]) data = last(portal.perZoneData[column.dataVar]);
         if (column.customFunction) data = column.customFunction(portal, data);
         if (GRAPHSETTINGS.toggles[this.id].perHr) { // HACKS a headache for future me if other toggles are wanted here.
-          data = data / (portal.perZoneData.currentTime.at(-1) / 3600000);
+          data = data / (last(portal.perZoneData.currentTime) / 3600000);
         }
         cleanData.push([portal.totalPortals, data])
       }
@@ -1111,7 +1115,7 @@ buildMapGrid = function () {
 }
 
 //On leaving maps for world
-// this captures the last map shen you switch away from maps
+// this captures the last map when you switch away from maps
 var originalmapsSwitch = mapsSwitch;
 mapsSwitch = function () {
   originalmapsSwitch(...arguments)

--- a/Graphs.js
+++ b/Graphs.js
@@ -1071,7 +1071,7 @@ var GRAPHSETTINGS = {
   rememberSelected: [],
   toggles: {},
   darkTheme: true,
-  maxGraphs: 100, // Highcharts gets a bit angry rendering more graphs, 30 is the maximum you can fit on the legend before it splits into pages.
+  maxGraphs: 60, // Highcharts gets a bit angry rendering more graphs, 30 is the maximum you can fit on the legend before it splits into pages.
   portalsDisplayed: 30
 }
 var portalSaveData = {}

--- a/Graphs.js
+++ b/Graphs.js
@@ -722,7 +722,7 @@ const graphList = [
     toggles: ["perHr", "perZone", "lifetime"]
   }],
   ["fluffy", 1, "Fluffy Exp", {
-    conditional: () => { return getGameData.u1hze() >= 300 && getGameData.fluffy() < 3413330078125000 }, // pre unlock, post E10L10
+    conditional: () => { return getGameData.u1hze() >= 299 && getGameData.fluffy() < 3413330078125000 }, // pre unlock, post E10L10
     customFunction: (portal, i) => { return diff("fluffy", portal.initialFluffy)(portal, i) },
     toggles: ["perHr", "perZone",]
   }],
@@ -734,7 +734,7 @@ const graphList = [
   }],
   ["lastWarp", 1, "Warpstations", {
     graphTitle: "Warpstations built on previous Giga",
-    conditional: () => { return getGameData.u1hze() > 60 && ((game.global.totalHeliumEarned - game.global.heliumLeftover) < 10 ** 10) }, // Warp unlock, less than 10B He allocated
+    conditional: () => { return getGameData.u1hze() >= 59 && ((game.global.totalHeliumEarned - game.global.heliumLeftover) < 10 ** 10) }, // Warp unlock, less than 10B He allocated
     xminFloor: 60,
   }],
   ["amals", 1, "Amalgamators"],
@@ -752,13 +752,13 @@ const graphList = [
     toggles: ["perHr", "perZone",]
   }],
   ["mutatedSeeds", 2, "Mutated Seeds", {
-    conditional: () => { return getGameData.u2hze() > 200 },
+    conditional: () => { return getGameData.u2hze() >= 200 },
     customFunction: (portal, i) => { return diff("mutatedSeeds", portal.initialMutes)(portal, i) },
     toggles: ["perHr", "perZone"],
     xminFloor: 200,
   }],
   ["worshippers", 2, "Worshippers", {
-    conditional: () => { return getGameData.u2hze() >= 50 },
+    conditional: () => { return getGameData.u2hze() >= 49 },
     xminFloor: 50,
   }],
   ["smithies", 2, "Smithies"],
@@ -797,8 +797,8 @@ const graphList = [
   ["overkill", false, "Overkill Cells", {
     // Overkill unlock zones (roughly)
     conditional: () => {
-      return ((getGameData.universe() == 1 && getGameData.u1hze() >= 170)
-        || getGameData.universe() == 2 && getGameData.u2hze() >= 201)
+      return ((getGameData.universe() == 1 && getGameData.u1hze() >= 169)
+        || (getGameData.universe() == 2 && getGameData.u2hze() >= 200))
     }
   }],
   ["mapbonus", false, "Map Bonus"],

--- a/Graphs.js
+++ b/Graphs.js
@@ -449,12 +449,12 @@ function Portal() {
   this.cinf = getGameData.cinf();
   if (this.universe === 1) {
     this.totalHelium = game.global.totalHeliumEarned;
-    this.initialFluffy = getGameData.fluffy();
+    this.initialFluffy = getGameData.fluffy() - game.stats.bestFluffyExp.value; // adjust for mid-run graph start
     this.initialDE = getGameData.essence();
   }
   if (this.universe === 2) {
     this.totalRadon = game.global.totalRadonEarned;
-    this.initialScruffy = getGameData.scruffy();
+    this.initialScruffy = getGameData.scruffy() - game.stats.bestFluffyExp2.value; // adjust for mid-run graph start
     this.s3 = getGameData.s3();
   }
   // create an object to collect only the relevant data per zone, without fromEntries because old JS

--- a/Graphs.js
+++ b/Graphs.js
@@ -260,6 +260,7 @@ function Graph(dataVar, universe, selectorText, additionalParams = {}) {
   this.lineGraph = function () {
     var item = this.dataVar;
     this.graphData = [];
+    // TODO all of the ugliness with restting to 'defaults' can be avoided if toggles modify the highcharts object instead of the graph object.
     this.graphTitle = this.baseGraphTitle;
     this.yTitle = this.selectorText;
     if (item === "currentTime") { // TODO This is the ugliest way to handle this, but it's a one off, shoot me.  Resets this graph to defaults.
@@ -477,6 +478,7 @@ function Portal() {
   if (this.universe === 2) {
     this.totalRadon = game.global.totalRadonEarned;
     this.initialScruffy = getGameData.scruffy() - game.stats.bestFluffyExp2.value; // adjust for mid-run graph start
+    this.initialMutes = getGameData.mutatedSeeds();
     this.s3 = getGameData.s3();
   }
   // create an object to collect only the relevant data per zone, without fromEntries because old JS
@@ -792,6 +794,11 @@ const graphList = [
     customFunction: (portal, i) => { return diff("scruffy", portal.initialScruffy)(portal, i) },
     toggles: ["perHr", "perZone",]
   }],
+  ["mutatedSeeds", 2, "Mutated Seeds", {
+    conditional: () => { return getGameData.u2hze() > 200 },
+    customFunction: (portal, i) => { return diff("mutatedSeeds", portal.initialMutes)(portal, i) },
+    toggles: ["perHr", "perZone"]
+  }],
   ["worshippers", 2, "Worshippers", {
     conditional: () => { return getGameData.u2hze() >= 50 }
   }],
@@ -904,6 +911,7 @@ const getGameData = {
     else { return 0; }
   },
   cinf: () => { return countChallengeSquaredReward(false, false, true) },
+  mutatedSeeds: () => { return game.global.mutatedSeedsSpent + game.global.mutatedSeeds }
 }
 
 var toggleProperties = { // rules for toggle based graphs

--- a/Graphs.js
+++ b/Graphs.js
@@ -546,7 +546,7 @@ function saveSelectedGraphs() {
 }
 function applyRememberedSelections() {
   for (let i = 0; i < chart1.series.length; i++) {
-    if (!GRAPHSETTINGS.rememberSelected[i]) { chart1.series[i].hide(); }
+    if (GRAPHSETTINGS.rememberSelected[i] === false) { chart1.series[i].hide(); }
   }
 }
 function toggleSpecificGraphs() {
@@ -608,7 +608,7 @@ function pushData() {
     portalSaveData[portalID] = new Portal();
   }
   portalSaveData[portalID].update();
-  clearData(50); // Safety value, probably too high
+  clearData(GRAPHSETTINGS.maxGraphs);
   savePortalData(false) // save current portal
 }
 
@@ -831,7 +831,8 @@ var GRAPHSETTINGS = {
   u2graphSelection: null,
   rememberSelected: [],
   toggles: {},
-  darkTheme: true
+  darkTheme: true,
+  maxGraphs: 20, // Highcharts gets a bit angry rendering more graphs, also 30 is the maximum you can fit on the legend before it splits into pages.  
 }
 var portalSaveData = {}
 

--- a/Graphs.js
+++ b/Graphs.js
@@ -965,6 +965,7 @@ var toggleProperties = { // rules for toggle based graphs
   },
   s3normalized: {
     graphMods: (graph) => {
+      var maxS3 = Math.max(...Object.values(portalSaveData).map((portal) => portal.s3).filter((s3) => s3));
       graph.graphTitle += `, Normalized to z${maxS3} S3`
     },
   },

--- a/GraphsOnly.js
+++ b/GraphsOnly.js
@@ -1,20 +1,14 @@
-var ATversion = 'Zek v5.1.0',
-    atscript = document.getElementById('AutoTrimps-script'),
-    basepath = 'https://Zorn192.github.io/AutoTrimps/', //Link to your own Github here if you forked!
-    modulepath = 'modules/';
-null !== atscript && (basepath = atscript.src.replace(/AutoTrimps2\.js$/, ''));
+var basepath = 'https://Quiaaaa.github.io/AutoTrimps/' //Link to your own Github here if you forked!
 
 //var isSteam = false;
 
-function ATscriptLoad(a, b) {
-    null == b && debug('Wrong Syntax. Script could not be loaded. Try ATscriptLoad(modulepath, \'example.js\'); ');
-    var c = document.createElement('script');
-    null == a && (a = ''), c.src = basepath + a + b + '.js', c.id = b + '_MODULE', document.head.appendChild(c)
-}
-
-function ATscriptUnload(a) {
-    var b = document.getElementById(a + "_MODULE");
-    b && (document.head.removeChild(b), debug("Removing " + a + "_MODULE", "other"))
+function ATscriptLoad(path, module) {
+    if (module == null) debug('Wrong Syntax. Script could not be loaded.')
+    if (path == null) path = '';
+    var scriptElem = document.createElement('script');
+    scriptElem.src = basepath + path + module + '.js'
+    scriptElem.id = module + '_MODULE'
+    document.head.appendChild(scriptElem)
 }
 
 function initializeGraphs() {
@@ -22,28 +16,13 @@ function initializeGraphs() {
     debug('AutoTrimps - Zek Graphs Only Fork Loaded!', '*spinner3');
 }
 
-function safeSetItems(name,data) {
-    try {
-        localStorage.setItem(name, data);
-    } catch(e) {
-      if (e.code == 22) {
-        // Storage full, maybe notify user or do some clean-up
-        debug("Error: LocalStorage is full, or error. Attempt to delete some portals from your graph or restart browser.");
-      }
-    }
-}
-
 var enableDebug = false;
 function debug(message, type, lootIcon) {
-    var output = true;
-    if (output) {
-        if (enableDebug)
-            console.debug(0 + ' ' + message);
-    }
+    if (enableDebug)
+        console.debug(0 + ' ' + message);
 }
 
 var MODULES = {}
-
 var startupDelay = 1000;
 setTimeout(initializeGraphs, startupDelay);
 

--- a/GraphsOnly.user.js
+++ b/GraphsOnly.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         AT-Zek-GraphsOnly
-// @namespace    https://github.com/Zorn192/AutoTrimps
+// @namespace    https://github.com/Quiaaaa/AutoTrimps
 // @version      2.6.1-Zek
-// @updateURL    https://github.com/Zorn192/AutoTrimps/GraphsOnly.user.js
+// @updateURL    https://github.com/Quiaaaa/AutoTrimps/GraphsOnly.user.js
 // @description  Graphs Module (only) from AutoTrimps
 // @author       zininzinin, spindrjr, belaith, ishakaru, genBTC, Zek
 // @include      *trimps.github.io*
@@ -11,6 +11,6 @@
 // ==/UserScript==
 var script = document.createElement('script');
 script.id = 'AutoTrimps-Graphs';
-script.src = 'https://Zorn192.github.io/AutoTrimps/GraphsOnly.js';
-script.setAttribute('crossorigin',"anonymous");
+script.src = 'https://Quiaaaa.github.io/AutoTrimps/GraphsOnly.js';
+script.setAttribute('crossorigin', "anonymous");
 document.head.appendChild(script);

--- a/GraphsOnly.user.js
+++ b/GraphsOnly.user.js
@@ -1,10 +1,10 @@
 // ==UserScript==
-// @name         AT-Zek-GraphsOnly
+// @name         AT-Quia-GraphsOnly
 // @namespace    https://github.com/Quiaaaa/AutoTrimps
-// @version      2.6.1-Zek
+// @version      3.0-Quia
 // @updateURL    https://github.com/Quiaaaa/AutoTrimps/GraphsOnly.user.js
 // @description  Graphs Module (only) from AutoTrimps
-// @author       zininzinin, spindrjr, belaith, ishakaru, genBTC, Zek
+// @author       zininzinin, spindrjr, belaith, ishakaru, genBTC, Zek, Quia
 // @include      *trimps.github.io*
 // @include      *kongregate.com/games/GreenSatellite/trimps
 // @grant        none

--- a/modsGRAPH.js
+++ b/modsGRAPH.js
@@ -1,5 +1,5 @@
 var script = document.createElement('script');
 script.id = 'AutoTrimps-Graphs';
-script.src = 'https://Zorn192.github.io/AutoTrimps/GraphsOnly.js';
-script.setAttribute('crossorigin',"anonymous");
+script.src = 'https://Quiaaaa.github.io/AutoTrimps/GraphsOnly.js';
+script.setAttribute('crossorigin', "anonymous");
 document.head.appendChild(script);


### PR DESCRIPTION
ALL THE GRAPHS

You should change the github paths back to yours.  Or leave them, and then we can have some fucking weird mess where your version is pointing at my version.  Might make it easier/faster to get any missed bugs fixed, because I'll be the one doing that.

CHANGELOG

**New Features**
Graphs that had separate graphs for Total, per Hour, % of lifetime, and normalized, are now consolidated on one graph each, with toggles to choose how you want it to display.
Time in maps and Maps run are now graphed! These are not the only new graphs, but they were a major pain in the ass, so they get featured here.
Live updates!
Limit the number of displayed graphs without deleting your saved history.
Per-portal total stats (Nu, Voids, He/Rn, Pet Exp, Run time) are now displayed in one handy column graph.
Graphs are now far more spoiler friendly. Graphs that aren't relevant to a save yet are not shown. This includes universe selection.
Graphs that are no longer relevant(capped, wrong challenge) are hidden.

**Improvements and bug fixes**
Graphs include the current zone stats, and update on portal to capture last-zone stats.
Hidden/visible portal selection persists through sessions.
S3 normalization now uses the highest S3 in your graphed data, instead of 0.
Graph colors are higher contrast, and no longer include an invisible gray.
Y axis labels now match in-game numerical format (Standard, Sci, Eng, etc.)
Time-based labels are now in d h m s, or s.ms where relevant.
More graphs! Up to 20 graphs saved, technically user modifiable.
Nonfunctional buttons removed.
Hotkeys are disabled when graphs are open: no more accidental stance swaps.
No more missing data from occlusion.
Reloading a save or refreshing the game correctly restarts the graph on your current zone.
All graphs respect the universe selection.
Pet exp graphs now start at 0 instead of wandering up the graph each portal.
Fluffy exp no longer goes negative when you evo.

**Backend improvements**
Graph storage size reduced by >90%.
Performance improved when there are lots of saved portals.
New graphs are much easier to add.
So much code cleanup. The code is brand new. Except for the frankensteined bits.